### PR TITLE
LFLT-392 Domino CLI can only be executed from its project directory

### DIFF
--- a/core/service/DominoService.py
+++ b/core/service/DominoService.py
@@ -32,10 +32,11 @@ class DominoService:
 
             if DominoService._is_successful(response):
                 print("Command {0} successfully executed on application {1}".format(domino_command.name, application))
-                DominoService._render_response(response)
             else:
                 print("Failed to execute command {0} on application {1} - Domino responded with {2}"
                       .format(domino_command.name, application, response.status_code))
+
+            DominoService._render_response(response)
 
         except Exception as exc:
             print("Failed to execute HTTP request {0} - reason {1}".format(domino_request, str(exc)))

--- a/domino_cli.py
+++ b/domino_cli.py
@@ -5,8 +5,17 @@ domino_cli.py :: Main entry point for Domino CLI application.
 
 __version__ = "1.0.0"
 
+import os
+
 from core.ApplicationContext import ApplicationContext
 
 
+def _set_work_dir() -> None:
+    script_path: str = os.path.realpath(__file__)
+    script_dir: str = os.path.dirname(script_path)
+    os.chdir(script_dir)
+
+
 if __name__ == "__main__":
+    _set_work_dir()
     ApplicationContext.init_cli().run_loop()


### PR DESCRIPTION
 - Added logic to set working directory on start-up
 - Unrelated: moved HTTP response rendering to render unsuccessful responses as well