### PR TITLE
LFLT-618 Make Domino CLI compatible with Domino Platform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea
 *.iml
 .coverage
+*.in
 htmlcov/
 out/

--- a/README.md
+++ b/README.md
@@ -131,14 +131,14 @@ Domino CLI also provides configuration wizards which help to properly create Dom
 Currently one configuration wizard is supported by the tool, but the list of wizards will be extended soon.
 
 ```
-wizard regconfig
+wizard deployment
 ```
-Starts wizard that helps creating a Domino application registration. Usage notes:
+Starts wizard that helps to create a Domino application deployment configuration. Usage notes:
 * Fixed choice steps are indicated by displaying the choices with a number in square brackets at the beginning
 of the line. Type the desired number and hit enter to select your choice.
 * Some steps may expect multiple responses. Hit enter after each of your answers. To finalize the step hit enter
 on an empty line.
 * Resulted configuration can be either displayed on console or written to file. If you chose to show the result
-on console, simply copy the displayed config into your existing Domino registration config file. If you want to 
-write the results to file, you need to define the file path when prompted. Having an already existing registration
+on console, simply copy the displayed config into your existing Domino deployment config file. If you want to 
+write the results to file, you need to define the file path when prompted. Having an already existing deployment
 configuration file will cause the tool to merge the newly created config with the existing file.

--- a/core/ApplicationContext.py
+++ b/core/ApplicationContext.py
@@ -21,10 +21,10 @@ from core.service.DominoService import DominoService
 from core.service.SessionContextHolder import SessionContextHolder
 from core.service.auth.DirectAuthHandler import DirectAuthHandler
 from core.service.auth.OAuthAuthHandler import OAuthAuthHandler
-from core.service.wizard.RegistrationConfigWizard import RegistrationConfigWizard
+from core.service.wizard.DeploymentConfigWizard import DeploymentConfigWizard
 from core.service.wizard.render.WizardResultConsoleRenderer import WizardResultConsoleRenderer
 from core.service.wizard.render.WizardResultFileRenderer import WizardResultFileRenderer
-from core.service.wizard.transformer.RegConfigWizardResultTransformer import RegConfigWizardResultTransformer
+from core.service.wizard.transformer.DeploymentConfigWizardResultTransformer import DeploymentConfigWizardResultTransformer
 
 
 class ApplicationContext:
@@ -44,10 +44,10 @@ class ApplicationContext:
         # wizards
         _wizard_result_console_renderer = WizardResultConsoleRenderer()
         _wizard_result_file_renderer = WizardResultFileRenderer()
-        _reg_config_wizard_result_transformer = RegConfigWizardResultTransformer()
-        _registration_config_wizard = RegistrationConfigWizard(_reg_config_wizard_result_transformer,
-                                                               _wizard_result_console_renderer,
-                                                               _wizard_result_file_renderer)
+        _reg_config_wizard_result_transformer = DeploymentConfigWizardResultTransformer()
+        _deployment_config_wizard = DeploymentConfigWizard(_reg_config_wizard_result_transformer,
+                                                           _wizard_result_console_renderer,
+                                                           _wizard_result_file_renderer)
 
         # common components
         _session_context_holder = SessionContextHolder()
@@ -61,7 +61,7 @@ class ApplicationContext:
             _oauth_auth_handler
         ])
         _config_wizard_service = ConfigurationWizardService([
-            _registration_config_wizard
+            _deployment_config_wizard
         ])
 
         # commands

--- a/core/service/auth/DirectAuthHandler.py
+++ b/core/service/auth/DirectAuthHandler.py
@@ -13,7 +13,7 @@ from core.service.auth.AuthUtils import AuthUtils
 class DirectAuthHandler(AbstractAuthHandler):
     """
     AbstractAuthHandler implementation using the legacy authentication flow of Domino. Request is sent directly to
-    Domino, calling the /claim-token endpoint, therefore. This mode requires Domino to be properly configured
+    Domino, calling the /claim-token endpoint. Therefore, this mode requires Domino to be properly configured
     regarding authentication (having the administrative user set up in Domino's config).
     """
     def __init__(self, domino_client: DominoClient):

--- a/core/service/wizard/mapping/DeploymentConfigWizardDataMapping.py
+++ b/core/service/wizard/mapping/DeploymentConfigWizardDataMapping.py
@@ -1,12 +1,13 @@
 from core.service.wizard.mapping.WizardDataMappingBaseEnum import WizardDataMappingBaseEnum
 
 
-class RegConfigWizardDataMapping(WizardDataMappingBaseEnum):
+class DeploymentConfigWizardDataMapping(WizardDataMappingBaseEnum):
     """
     Field mappings between raw wizard response data and target data dictionaries.
     """
-    REGISTRATION_NAME = ("reg_name", "$root")
+    DEPLOYMENT_NAME = ("deployment_name", "$root")
     SOURCE_TYPE = ("source_type", "$root.source.type")
+    TARGET_HOSTS = ("target_hosts", "$root.target.hosts")
     EXEC_TYPE = ("exec_type", "$root.execution.via")
     SOURCE_HOME = ("src_home", "$root.source.home")
     BINARY_NAME = ("src_bin_name", "$root.source.resource")

--- a/core/service/wizard/transformer/DeploymentConfigWizardResultTransformer.py
+++ b/core/service/wizard/transformer/DeploymentConfigWizardResultTransformer.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from core.service.wizard.mapping.RegConfigWizardDataMapping import RegConfigWizardDataMapping as Mapping
+from core.service.wizard.mapping.DeploymentConfigWizardDataMapping import DeploymentConfigWizardDataMapping as Mapping
 from core.service.wizard.transformer.AbstractWizardResultTransformer import AbstractWizardResultTransformer
 
 _SOURCE_TYPE_FILESYSTEM = "FILESYSTEM"
@@ -10,12 +10,12 @@ _EXEC_TYPE_RUNTIME = "RUNTIME"
 _EXEC_TYPE_SERVICE = "SERVICE"
 _EXEC_TYPE_DOCKER_STANDARD = "STANDARD"
 
-_REGISTRATION_ROOT = "domino.registrations.{0}"
+_DEPLOYMENT_ROOT = "domino.deployments.{0}"
 _DEFAULT_OPTIONS_TO_BOOLEAN_MAPPER = (lambda value: value == "yes")
 _UPPERCASE_MAPPER = (lambda value: str(value).upper())
 
 
-class RegConfigWizardResultTransformer(AbstractWizardResultTransformer):
+class DeploymentConfigWizardResultTransformer(AbstractWizardResultTransformer):
     """
     AbstractWizardResultTransformer implementation for registration config wizard.
     """
@@ -35,7 +35,7 @@ class RegConfigWizardResultTransformer(AbstractWizardResultTransformer):
         :param source: source dict object
         :return: transformed Domino registration configuration
         """
-        root_node: str = _REGISTRATION_ROOT.format(source[Mapping.REGISTRATION_NAME.get_wizard_field()])
+        root_node: str = _DEPLOYMENT_ROOT.format(source[Mapping.DEPLOYMENT_NAME.get_wizard_field()])
         target_dict: dict = self._define_base_dict(root_node, source)
         exec_type: str = self._read_current_value(Mapping.EXEC_TYPE, root_node, target_dict)
         self._exec_type_parameter_filler_mapping.get(exec_type)(root_node, source, target_dict)
@@ -48,6 +48,7 @@ class RegConfigWizardResultTransformer(AbstractWizardResultTransformer):
 
         target_dict: dict = {}
         self._assign(Mapping.SOURCE_TYPE, root_node, source, target_dict, _UPPERCASE_MAPPER)
+        self._assign(Mapping.TARGET_HOSTS, root_node, source, target_dict)
         self._assign(Mapping.EXEC_TYPE, root_node, source, target_dict, _UPPERCASE_MAPPER)
         self._assign(Mapping.HEALTH_CHECK_ENABLE, root_node, source, target_dict, _DEFAULT_OPTIONS_TO_BOOLEAN_MAPPER)
         self._assign(Mapping.INFO_ENABLE, root_node, source, target_dict, _DEFAULT_OPTIONS_TO_BOOLEAN_MAPPER)

--- a/domino_cli.py
+++ b/domino_cli.py
@@ -3,7 +3,7 @@
 domino_cli.py :: Main entry point for Domino CLI application.
 """
 
-__version__ = "1.3.0"
+__version__ = "2.0.0-beta"
 
 import os
 

--- a/test/core/service/wizard/test_DeploymentConfigWizard.py
+++ b/test/core/service/wizard/test_DeploymentConfigWizard.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest import mock
 
-from core.service.wizard.RegistrationConfigWizard import RegistrationConfigWizard
+from core.service.wizard.DeploymentConfigWizard import DeploymentConfigWizard
 from core.service.wizard.render.WizardResultConsoleRenderer import WizardResultConsoleRenderer
 from core.service.wizard.render.WizardResultFileRenderer import WizardResultFileRenderer
 from core.service.wizard.transformer.AbstractWizardResultTransformer import AbstractWizardResultTransformer
@@ -10,6 +10,9 @@ _TRANSFORMED_VALUE = {"transformed": {}}
 
 _EXECUTABLE_TYPE_RAW_RESPONSES = [
     "app1",
+    "devlocal",
+    "localhost",
+    "",
     "1",
     "1",
     "/home",
@@ -27,7 +30,11 @@ _EXECUTABLE_TYPE_RAW_RESPONSES = [
     "1"
 ]
 _EXECUTABLE_TYPE_FORMATTED_RESPONSE_DICT: dict = {
-    "reg_name": "app1",
+    "deployment_name": "app1",
+    "target_hosts": [
+        "devlocal",
+        "localhost"
+    ],
     "source_type": "filesystem",
     "exec_type": "executable",
     "src_home": "/home",
@@ -48,6 +55,8 @@ _EXECUTABLE_TYPE_FORMATTED_RESPONSE_DICT: dict = {
 
 _RUNTIME_TYPE_RAW_RESPONSES = [
     "app2",
+    "localhost",
+    "",
     "1",
     "2",
     "/home",
@@ -61,8 +70,11 @@ _RUNTIME_TYPE_RAW_RESPONSES = [
     "1"
 ]
 _RUNTIME_TYPE_FORMATTED_RESPONSE_DICT: dict = {
-    "reg_name": "app2",
+    "deployment_name": "app2",
     "source_type": "filesystem",
+    "target_hosts": [
+        "localhost"
+    ],
     "exec_type": "runtime",
     "src_home": "/home",
     "src_bin_name": "app2-exec.jar",
@@ -78,6 +90,8 @@ _RUNTIME_TYPE_FORMATTED_RESPONSE_DICT: dict = {
 
 _SERVICE_TYPE_RAW_RESPONSES = [
     "app3",
+    "localhost",
+    "",
     "1",
     "3",
     "/home",
@@ -89,8 +103,11 @@ _SERVICE_TYPE_RAW_RESPONSES = [
     "2"
 ]
 _SERVICE_TYPE_FORMATTED_RESPONSE_DICT: dict = {
-    "reg_name": "app3",
+    "deployment_name": "app3",
     "source_type": "filesystem",
+    "target_hosts": [
+        "localhost"
+    ],
     "exec_type": "service",
     "src_home": "/home",
     "src_bin_name": "app3-exec.jar",
@@ -103,6 +120,8 @@ _SERVICE_TYPE_FORMATTED_RESPONSE_DICT: dict = {
 
 _DOCKER_STANDARD_TYPE_RAW_RESPONSES = [
     "app4",
+    "localhost",
+    "",
     "2",
     "1",
     "http://localhost:5000/apps",
@@ -133,8 +152,11 @@ _DOCKER_STANDARD_TYPE_RAW_RESPONSES = [
     "1"
 ]
 _DOCKER_STANDARD_TYPE_FORMATTED_RESPONSE_DICT: dict = {
-    "reg_name": "app4",
+    "deployment_name": "app4",
     "source_type": "docker",
+    "target_hosts": [
+        "localhost"
+    ],
     "exec_type": "standard",
     "src_home": "http://localhost:5000/apps",
     "src_bin_name": "img_app4",
@@ -170,7 +192,7 @@ _DOCKER_STANDARD_TYPE_FORMATTED_RESPONSE_DICT: dict = {
 }
 
 
-class RegistrationConfigWizardTest(unittest.TestCase):
+class DeploymentConfigWizardTest(unittest.TestCase):
 
     def setUp(self) -> None:
         self.wizard_result_transformer_mock: AbstractWizardResultTransformer = mock.create_autospec(AbstractWizardResultTransformer)
@@ -179,7 +201,7 @@ class RegistrationConfigWizardTest(unittest.TestCase):
 
         self.wizard_result_transformer_mock.transform.return_value = _TRANSFORMED_VALUE
 
-        self.registration_config_wizard: RegistrationConfigWizard = RegistrationConfigWizard(
+        self.registration_config_wizard: DeploymentConfigWizard = DeploymentConfigWizard(
             self.wizard_result_transformer_mock,
             self.wizard_result_console_renderer_mock,
             self.wizard_result_file_renderer_mock)
@@ -212,7 +234,7 @@ class RegistrationConfigWizardTest(unittest.TestCase):
 
         # then
         file_renderer_call_args = self.wizard_result_file_renderer_mock.render.call_args.args
-        merge_lambda_result = file_renderer_call_args[1]({"domino": {"registrations": {"key": "value"}}})
+        merge_lambda_result = file_renderer_call_args[1]({"domino": {"deployments": {"key": "value"}}})
 
         self.wizard_result_transformer_mock.transform.assert_called_once_with(_SERVICE_TYPE_FORMATTED_RESPONSE_DICT)
         self.assertEqual(file_renderer_call_args[0], _TRANSFORMED_VALUE)

--- a/test/core/service/wizard/transformer/test_DeploymentConfigWizardResultTransformer.py
+++ b/test/core/service/wizard/transformer/test_DeploymentConfigWizardResultTransformer.py
@@ -1,9 +1,13 @@
 import unittest
 
-from core.service.wizard.transformer.RegConfigWizardResultTransformer import RegConfigWizardResultTransformer
+from core.service.wizard.transformer.DeploymentConfigWizardResultTransformer import DeploymentConfigWizardResultTransformer
 
-_REG_CONFIG_EXECUTABLE_RAW: dict = {
-    "reg_name": "app1",
+_DEPLOYMENT_CONFIG_EXECUTABLE_RAW: dict = {
+    "deployment_name": "app1",
+    "target_hosts": [
+        "devlocal",
+        "localhost"
+    ],
     "source_type": "filesystem",
     "exec_type": "executable",
     "src_home": "/home",
@@ -20,14 +24,20 @@ _REG_CONFIG_EXECUTABLE_RAW: dict = {
     "hc_endpoint": "http://localhost:8099/health",
     "info_enable": "no"
 }
-_REG_CONFIG_EXECUTABLE_TRANSFORMED: dict = {
+_DEPLOYMENT_CONFIG_EXECUTABLE_TRANSFORMED: dict = {
     "domino": {
-        "registrations": {
+        "deployments": {
             "app1": {
                 "source": {
                     "type": "FILESYSTEM",
                     "home": "/home",
                     "resource": "app1-exec.jar"
+                },
+                "target": {
+                    "hosts": [
+                        "devlocal",
+                        "localhost"
+                    ]
                 },
                 "execution": {
                     "via": "EXECUTABLE",
@@ -52,8 +62,11 @@ _REG_CONFIG_EXECUTABLE_TRANSFORMED: dict = {
     }
 }
 
-_REG_CONFIG_RUNTIME_RAW: dict = {
-    "reg_name": "app2",
+_DEPLOYMENT_CONFIG_RUNTIME_RAW: dict = {
+    "deployment_name": "app2",
+    "target_hosts": [
+        "localhost"
+    ],
     "source_type": "filesystem",
     "exec_type": "runtime",
     "src_home": "/home",
@@ -71,14 +84,19 @@ _REG_CONFIG_RUNTIME_RAW: dict = {
         "version": "$.build.version"
     }
 }
-_REG_CONFIG_RUNTIME_TRANSFORMED: dict = {
+_DEPLOYMENT_CONFIG_RUNTIME_TRANSFORMED: dict = {
     "domino": {
-        "registrations": {
+        "deployments": {
             "app2": {
                 "source": {
                     "type": "FILESYSTEM",
                     "home": "/home",
                     "resource": "app2-exec.jar"
+                },
+                "target": {
+                    "hosts": [
+                        "localhost"
+                    ]
                 },
                 "execution": {
                     "via": "RUNTIME",
@@ -104,8 +122,11 @@ _REG_CONFIG_RUNTIME_TRANSFORMED: dict = {
     }
 }
 
-_REG_CONFIG_SERVICE_RAW: dict = {
-    "reg_name": "app3",
+_DEPLOYMENT_CONFIG_SERVICE_RAW: dict = {
+    "deployment_name": "app3",
+    "target_hosts": [
+        "localhost"
+    ],
     "source_type": "filesystem",
     "exec_type": "service",
     "src_home": "/home",
@@ -115,14 +136,19 @@ _REG_CONFIG_SERVICE_RAW: dict = {
     "hc_enable": "no",
     "info_enable": "no"
 }
-_REG_CONFIG_SERVICE_TRANSFORMED: dict = {
+_DEPLOYMENT_CONFIG_SERVICE_TRANSFORMED: dict = {
     "domino": {
-        "registrations": {
+        "deployments": {
             "app3": {
                 "source": {
                     "type": "FILESYSTEM",
                     "home": "/home",
                     "resource": "app3-exec.jar"
+                },
+                "target": {
+                    "hosts": [
+                        "localhost"
+                    ]
                 },
                 "execution": {
                     "via": "SERVICE",
@@ -140,8 +166,11 @@ _REG_CONFIG_SERVICE_TRANSFORMED: dict = {
     }
 }
 
-_REG_CONFIG_DOCKER_STANDARD_RAW: dict = {
-    "reg_name": "app4",
+_DEPLOYMENT_CONFIG_DOCKER_STANDARD_RAW: dict = {
+    "deployment_name": "app4",
+    "target_hosts": [
+        "localhost"
+    ],
     "source_type": "docker",
     "exec_type": "standard",
     "src_home": "http://localhost:5000/apps",
@@ -170,14 +199,19 @@ _REG_CONFIG_DOCKER_STANDARD_RAW: dict = {
     "hc_enable": "no",
     "info_enable": "no"
 }
-_REG_CONFIG_DOCKER_STANDARD_TRANSFORMED: dict = {
+_DEPLOYMENT_CONFIG_DOCKER_STANDARD_TRANSFORMED: dict = {
     "domino": {
-        "registrations": {
+        "deployments": {
             "app4": {
                 "source": {
                     "type": "DOCKER",
                     "home": "http://localhost:5000/apps",
                     "resource": "img_app4"
+                },
+                "target": {
+                    "hosts": [
+                        "localhost"
+                    ]
                 },
                 "execution": {
                     "via": "STANDARD",
@@ -217,18 +251,18 @@ _REG_CONFIG_DOCKER_STANDARD_TRANSFORMED: dict = {
 }
 
 
-class RegConfigWizardResultTransformerTest(unittest.TestCase):
+class DeploymentConfigWizardResultTransformerTest(unittest.TestCase):
 
     def setUp(self) -> None:
-        self.reg_config_wizard_result_transformer: RegConfigWizardResultTransformer = RegConfigWizardResultTransformer()
+        self.deployment_config_wizard_result_transformer: DeploymentConfigWizardResultTransformer = DeploymentConfigWizardResultTransformer()
 
     def test_should_transform(self):
 
-        for (source, expected_target) in RegConfigWizardResultTransformerTest._prepare_parameters():
+        for (source, expected_target) in DeploymentConfigWizardResultTransformerTest._prepare_parameters():
             with self.subTest("answer dictionary transformation", source=source, expected_target=expected_target):
 
                 # when
-                result: dict = self.reg_config_wizard_result_transformer.transform(source)
+                result: dict = self.deployment_config_wizard_result_transformer.transform(source)
 
                 # then
                 self.assertEqual(result, expected_target)
@@ -236,10 +270,10 @@ class RegConfigWizardResultTransformerTest(unittest.TestCase):
     @staticmethod
     def _prepare_parameters():
         return [
-            (_REG_CONFIG_EXECUTABLE_RAW, _REG_CONFIG_EXECUTABLE_TRANSFORMED),
-            (_REG_CONFIG_RUNTIME_RAW, _REG_CONFIG_RUNTIME_TRANSFORMED),
-            (_REG_CONFIG_SERVICE_RAW, _REG_CONFIG_SERVICE_TRANSFORMED),
-            (_REG_CONFIG_DOCKER_STANDARD_RAW, _REG_CONFIG_DOCKER_STANDARD_TRANSFORMED)
+            (_DEPLOYMENT_CONFIG_EXECUTABLE_RAW, _DEPLOYMENT_CONFIG_EXECUTABLE_TRANSFORMED),
+            (_DEPLOYMENT_CONFIG_RUNTIME_RAW, _DEPLOYMENT_CONFIG_RUNTIME_TRANSFORMED),
+            (_DEPLOYMENT_CONFIG_SERVICE_RAW, _DEPLOYMENT_CONFIG_SERVICE_TRANSFORMED),
+            (_DEPLOYMENT_CONFIG_DOCKER_STANDARD_RAW, _DEPLOYMENT_CONFIG_DOCKER_STANDARD_TRANSFORMED)
         ]
 
 


### PR DESCRIPTION
 - Renamed "regconfig" wizard to "deployment"
 - Renamed "registrations" node to "deployments" in deployment config generated by the wizard
 - Added target.hosts node to deployment config
 - Aligned related unit tests
 - Aligned documentation
 - Bumped CLI version to 2.0.0-beta