### PR TITLE
LFLT-622 Domino CLI distribution is changed to Python wheel based

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ executors:
       - image: cimg/python:3.12
   base:
     docker:
-      - image: img/base:stable
+      - image: cimg/base:stable
 
 jobs:
 


### PR DESCRIPTION
 - Fixed cimg/base Docker image name