### PR TITLE
LFLT-622 Domino CLI distribution is changed to Python wheel based

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ parameters:
     default: dist/
   distribution_archive_prefix:
     type: string
-    default: domino-cli-
+    default: domino_cli-
   distribution_archive_extension:
     type: string
     default: .tar.gz


### PR DESCRIPTION
 - Fixed distribution archive name for GitHub release