### PR TITLE
LFLT-632 Implement CI/CD mode for Domino CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,18 +15,20 @@ also generate configuration files for each Domino Platform components, as well a
 
 The tool can be configured via the following environment variables:
 
-| Environment variable       | Mandatory?    | Description                                                                                   |
-|----------------------------|---------------|-----------------------------------------------------------------------------------------------|
-| DOMINO_BASE_URL            | Yes           | URL of Domino instance to be controlled, e.g. http://localhost:8080/domino                    |
-| DOMINO_CLI_USERNAME        | No            | Optional predefined username for accessing Domino                                             |
-| DOMINO_CLI_PASSWORD        | No            | Optional predefined password for accessing Domino                                             |
-| DOMINO_CLI_DEBUG_MODE      | No            | Optional debug switch. Currently its only effect is echoing the parsed command                |
-| DOMINO_DEFAULT_AUTH_MODE   | No            | Changes how Domino CLI acquires the access token for Domino. Defaults to direct mode (legacy) |
-| DOMINO_OAUTH_TOKEN_URL     | In OAuth mode | OAuth 2.0 compliant authorization server address, including the token request endpoint path   |
-| DOMINO_OAUTH_CLIENT_ID     | In OAuth mode | OAuth 2.0 Client ID of Domino CLI                                                             |
-| DOMINO_OAUTH_CLIENT_SECRET | In OAuth mode | OAuth 2.0 Client Secret of Domino CLI                                                         |
-| DOMINO_OAUTH_SCOPE         | In OAuth mode | OAuth 2.0 access token scope                                                                  |                                                                                         
-| DOMINO_OAUTH_AUDIENCE      | No            | OAuth 2.0 audience of Domino                                                                  |
+| Environment variable           | Mandatory?    | Description                                                                                                      |
+|--------------------------------|---------------|------------------------------------------------------------------------------------------------------------------|
+| DOMINO_BASE_URL                | Yes           | URL of Domino instance to be controlled, e.g. http://localhost:8080/domino                                       |
+| DOMINO_CLI_USERNAME            | No            | Optional predefined username for accessing Domino                                                                |
+| DOMINO_CLI_PASSWORD            | No            | Optional predefined password for accessing Domino                                                                |
+| DOMINO_CLI_PREAUTHORIZED_TOKEN | No            | (For CI/CD mode) Passes an already generated access token - see further information in [CI/CD mode](#cicd-mode)) |
+| DOMINO_CLI_DEBUG_MODE          | No            | Optional debug switch. Currently its only effect is echoing the parsed command                                   |
+| DOMINO_CLI_DISABLE_COLORS      | No            | Optional switch to disable terminal colors.                                                                      |
+| DOMINO_DEFAULT_AUTH_MODE       | No            | Changes how Domino CLI acquires the access token for Domino. Defaults to direct mode (legacy)                    |
+| DOMINO_OAUTH_TOKEN_URL         | In OAuth mode | OAuth 2.0 compliant authorization server address, including the token request endpoint path                      |
+| DOMINO_OAUTH_CLIENT_ID         | In OAuth mode | OAuth 2.0 Client ID of Domino CLI                                                                                |
+| DOMINO_OAUTH_CLIENT_SECRET     | In OAuth mode | OAuth 2.0 Client Secret of Domino CLI                                                                            |
+| DOMINO_OAUTH_SCOPE             | In OAuth mode | OAuth 2.0 access token scope                                                                                     |                                                                                         
+| DOMINO_OAUTH_AUDIENCE          | No            | OAuth 2.0 audience of Domino                                                                                     |
 
 ## Installation
 
@@ -66,6 +68,29 @@ After this step, you can start Domino CLI:
 ```shell
 domino-cli
 ```
+
+### CI/CD mode
+
+Domino CLI now supports execution in so-called CI/CD mode, which is a simplified execution mode, primarily to be used on
+CI/CD environments, usually within a deployment script. There are a few things to note here:
+* To execute Domino CLI in CI/CD mode, pass the `--cicd` switch as the first command line parameter, then the command
+  you wish to execute, e.g. like this:
+   ```bash
+  domino-cli --cicd deploy your_app latest
+   ```
+* Interactive terminal is not available in CI/CD mode, you may only execute a single command at a time, then Domino CLI
+  immediately quits with `exit 0` status code, or `exit 1` in case of any error.
+* This also means, you can't open an authorized session. Instead, you may call the `auth --generate-token` command and 
+set the result (the generated access token) as the `DOMINO_CLI_PREAUTHORIZED_TOKEN` environment variable, e.g. as follows:
+   ```bash
+  export DOMINO_CLI_PREAUTHORIZED_TOKEN="$(domino-cli --cicd auth --generate-token)"
+  # the token in DOMINO_CLI_PREAUTHORIZED_TOKEN will be used by Domino CLI to authorize any further operations
+  domino-cli --cicd deploy your_app latest
+  domino-cli --cicd start your_app
+   ```
+* Please note, that without the interactive terminal, any operation that depends on user input, is not available,
+  including the configuration wizards, and manual authentication (you need to define the necessary parameters as
+  environment variables, as described above in the [Configuration section](#configuration))
 
 ## Usage
 After successfully starting up Domino CLI you should see its prompt (`Domino CLI >`) along with some start-up messages.

--- a/domino_cli/__init__.py
+++ b/domino_cli/__init__.py
@@ -2,7 +2,7 @@
 domino_cli.py :: Main entry point for Domino CLI application.
 """
 
-__version__ = "2.1.0"
+__version__ = "2.2.0"
 
 import os
 

--- a/domino_cli/core/ApplicationContext.py
+++ b/domino_cli/core/ApplicationContext.py
@@ -1,6 +1,7 @@
 import os
 
 from domino_cli.core.cli.CLI import CLI
+from domino_cli.core.cli.Logging import info
 from domino_cli.core.client.DominoClient import DominoClient
 from domino_cli.core.client.OAuthAuthorizationClient import OAuthAuthorizationClient
 from domino_cli.core.command.AuthCommand import AuthCommand
@@ -50,7 +51,7 @@ class ApplicationContext:
     @staticmethod
     def init_cli(version: str) -> CLI:
 
-        print("Initializing Domino CLI...")
+        info("Initializing Domino CLI...")
 
         # configuration properties
         _domino_base_url = ApplicationContext._assert_config_value("DOMINO_BASE_URL")
@@ -129,8 +130,8 @@ class ApplicationContext:
 
         _cli = CLI(_command_processor)
 
-        print(f"Domino CLI v{version} initialized.")
-        print("-" * 30)
+        info(f"Domino CLI v{version} initialized")
+        info("-" * 30)
 
         return _cli
 

--- a/domino_cli/core/cli/CLI.py
+++ b/domino_cli/core/cli/CLI.py
@@ -1,7 +1,9 @@
+from domino_cli.core.cli.Logging import TerminalColor, get_color
+from domino_cli.core.cli.RuntimeHelper import RuntimeHelper
 from domino_cli.core.domain.CommandDescriptor import CommandDescriptor
 from domino_cli.core.service.CommandProcessor import CommandProcessor
 
-_PROMPT = "\nDomino CLI > "
+_PROMPT = f"\n{get_color(TerminalColor.BLUE)}Domino CLI > {get_color(TerminalColor.NORMAL)}"
 
 
 class CLI:
@@ -13,10 +15,16 @@ class CLI:
 
     def run_loop(self) -> None:
         """
-        Runs CLI command execution loop until an exit command terminates it.
+        Executes a single command (passed from the command line) in CI/CD mode, otherwise runs CLI command execution
+        loop until an exit command terminates it.
         """
+        if RuntimeHelper.is_cicd_mode():
+            command = CommandDescriptor(RuntimeHelper.get_cicd_command_line())
+            self._command_processor.execute_command(command)
+            return
+
         while True:
-            command = CommandDescriptor(input(_PROMPT))
+            command = CommandDescriptor(RuntimeHelper.input_wrapper(lambda: input(_PROMPT)))
             continue_loop = self._command_processor.execute_command(command)
 
             if not continue_loop:

--- a/domino_cli/core/cli/Logging.py
+++ b/domino_cli/core/cli/Logging.py
@@ -1,0 +1,68 @@
+import os
+import string
+import sys
+from enum import Enum
+
+from domino_cli.core.cli.RuntimeHelper import RuntimeHelper
+
+
+class TerminalColor(Enum):
+    GREEN = "\033[92m"
+    YELLOW = "\033[93m"
+    RED = "\033[91m"
+    BLUE = "\033[94m"
+    NORMAL = "\033[0m"
+
+
+class LogLevel(Enum):
+    INFO = "info"
+    WARNING = "warn"
+    ERROR = "error"
+
+_terminal_color_mapping: dict[LogLevel, TerminalColor] = {
+    LogLevel.INFO: TerminalColor.GREEN,
+    LogLevel.WARNING: TerminalColor.YELLOW,
+    LogLevel.ERROR: TerminalColor.RED,
+}
+
+
+def info(message: string) -> None:
+    """
+    Logs the given message on info level. Ignores logging in CI/CD mode.
+
+    :param message: message to log
+    """
+    _log(LogLevel.INFO, message, False)
+
+def warning(message: string) -> None:
+    """
+    Logs the given message on warn level. Ignores logging in CI/CD mode.
+
+    :param message: message to log
+    """
+    _log(LogLevel.WARNING, message, False)
+
+def error(message: string) -> None:
+    """
+    Logs the given message on error level. Logs the given message even in CI/CD mode.
+
+    :param message: message to log
+    """
+    _log(LogLevel.ERROR, message, True)
+
+def get_color(color: TerminalColor) -> str:
+    """
+    Returns the terminal color code assigned to the given TerminalColor, if using terminal colors is enabled. Otherwise,
+    returns an empty string.
+
+    :param color: TerminalColor enum constant
+    :return: color code or empty string
+    """
+    return "" \
+        if os.getenv("DOMINO_CLI_DISABLE_COLORS") is not None or "unittest" in sys.modules \
+        else color.value
+
+def _log(log_level: LogLevel, message: string, force: bool = False) -> None:
+
+    if not RuntimeHelper.is_cicd_mode() or force:
+        print(f"[{get_color(_terminal_color_mapping[log_level])}{log_level.value:5}{get_color(TerminalColor.NORMAL)}] {message}")

--- a/domino_cli/core/cli/RuntimeHelper.py
+++ b/domino_cli/core/cli/RuntimeHelper.py
@@ -1,0 +1,64 @@
+import sys
+
+
+class RuntimeHelper:
+    """
+    Runtime helper utilities.
+    """
+
+    _cicd_mode = len(sys.argv) > 1 and sys.argv[1] == "--cicd"
+
+    @classmethod
+    def is_cicd_mode(cls) -> bool:
+        """
+        Checks if the CLI was executed in CI/CD mode. CI/CD mode only allows executing a single command, defined
+        directly in the command line. The same commands and parameterization should be used as before, but in order to
+        run the CLI in CI/CD mode, the first parameter should be "--cicd". E.g. domino-cli --cicd deploy app 1.0.0.
+        For further information, see the relevant section of the documentation in README.md.
+
+        :return: true if CI/CD mode is enabled, false otherwise.
+        """
+        return cls._cicd_mode
+
+    @classmethod
+    def get_cicd_command_line(cls) -> str:
+        """
+        Returns the CI/CD command line, without the --cicd flag itself, only if the CLI is running in CI/CD mode.
+        Otherwise, it returns None.
+
+        :return: CI/CD command line without --cicd flag
+        """
+        return " ".join(sys.argv[2:]) \
+            if cls._cicd_mode \
+            else None
+
+    @classmethod
+    def input_wrapper(cls, input_call: lambda: str) -> str:
+        """
+        Checks if the CLI is running in CI/CD mode before executing an input call. If so, immediately quits, otherwise
+        executes the input call.
+
+        :param input_call: input call to be executed
+        :return: result of the input call
+        """
+        cls.unsupported_in_cicd_mode()
+
+        return input_call()
+
+    @classmethod
+    def exit_with_error_in_cicd_mode(cls) -> None:
+        """
+        Closes the CLI application with exit status 1 in CI/CD mode. Can be used to terminate the CLI on exception.
+        """
+        if cls._cicd_mode:
+            exit(1)
+
+    @classmethod
+    def unsupported_in_cicd_mode(cls) -> None:
+        """
+        Closes the CLI application with exit status 1 in CI/CD mode. Can be used to terminate the CLI when an
+        unsupported operation is executed in CI/CD mode.
+        """
+        if cls._cicd_mode:
+            print("[error] This operation is not supported in CI/CD mode")
+            exit(1)

--- a/domino_cli/core/client/DominoClient.py
+++ b/domino_cli/core/client/DominoClient.py
@@ -3,6 +3,7 @@ import urllib.parse
 import requests
 from requests import Response
 
+from domino_cli.core.cli.Logging import info
 from domino_cli.core.domain.DominoRequest import DominoRequest
 from domino_cli.core.service.SessionContextHolder import SessionContextHolder
 
@@ -15,7 +16,7 @@ class DominoClient:
         self._domino_base_url = domino_base_url
         self._session_context_holder = session_context_holder
 
-        print("Domino CLI is configured to communicate with Domino on {0}".format(domino_base_url))
+        info("Domino CLI is configured to communicate with Domino on {0}".format(domino_base_url))
 
     def send_command(self, domino_request: DominoRequest) -> Response:
         """

--- a/domino_cli/core/command/AbstractLifecycleCommand.py
+++ b/domino_cli/core/command/AbstractLifecycleCommand.py
@@ -1,3 +1,4 @@
+from domino_cli.core.cli.Logging import warning
 from domino_cli.core.command.AbstractCommand import AbstractCommand
 from domino_cli.core.domain.CommandDescriptor import CommandDescriptor
 from domino_cli.core.domain.DominoCommand import DominoCommand
@@ -21,6 +22,6 @@ class AbstractLifecycleCommand(AbstractCommand):
         :param command_descriptor: CommandDescriptor object containing the command arguments
         """
         if not len(command_descriptor.arguments) == 1:
-            print("Application name required")
+            warning("Application name required")
         else:
             self._domino_service.execute_lifecycle_command(self._domino_command, command_descriptor.arguments[0])

--- a/domino_cli/core/command/AuthCommand.py
+++ b/domino_cli/core/command/AuthCommand.py
@@ -1,3 +1,4 @@
+from domino_cli.core.cli.Logging import warning
 from domino_cli.core.command.AbstractCommand import AbstractCommand
 from domino_cli.core.domain.CommandDescriptor import CommandDescriptor
 from domino_cli.core.service.AuthenticationService import AuthenticationService
@@ -42,5 +43,5 @@ class AuthCommand(AbstractCommand):
 
     @staticmethod
     def _show_help():
-        print("Auth command requires operation flag of: --encrypt-password | --generate-token | --open-session "
+        warning("Auth command requires operation flag of: --encrypt-password | --generate-token | --open-session "
               "| --set-mode direct|oauth")

--- a/domino_cli/core/command/DeployApplicationCommand.py
+++ b/domino_cli/core/command/DeployApplicationCommand.py
@@ -1,3 +1,4 @@
+from domino_cli.core.cli.Logging import warning
 from domino_cli.core.command.AbstractCommand import AbstractCommand
 from domino_cli.core.domain.CommandDescriptor import CommandDescriptor
 from domino_cli.core.domain.DominoCommand import DominoCommand
@@ -25,7 +26,7 @@ class DeployApplicationCommand(AbstractCommand):
         :param command_descriptor: CommandDescriptor object containing the command arguments
         """
         if not len(command_descriptor.arguments) == 2:
-            print("Application name and 'latest' keyword or explicit version is required")
+            warning("Application name and 'latest' keyword or explicit version is required")
         else:
             application: str = command_descriptor.arguments[0]
             version: str = command_descriptor.arguments[1]

--- a/domino_cli/core/command/ExitCommand.py
+++ b/domino_cli/core/command/ExitCommand.py
@@ -1,5 +1,6 @@
-from domino_cli.core.domain.CommandDescriptor import CommandDescriptor
+from domino_cli.core.cli.Logging import info
 from domino_cli.core.command.AbstractCommand import AbstractCommand
+from domino_cli.core.domain.CommandDescriptor import CommandDescriptor
 
 _COMMAND_NAME = "exit"
 
@@ -13,4 +14,4 @@ class ExitCommand(AbstractCommand):
         super().__init__(_COMMAND_NAME)
 
     def execute_command(self, command_descriptor: CommandDescriptor) -> None:
-        print("Bye!")
+        info("Bye!")

--- a/domino_cli/core/command/HelpCommand.py
+++ b/domino_cli/core/command/HelpCommand.py
@@ -1,5 +1,6 @@
-from domino_cli.core.domain.CommandDescriptor import CommandDescriptor
+from domino_cli.core.cli.RuntimeHelper import RuntimeHelper
 from domino_cli.core.command.AbstractCommand import AbstractCommand
+from domino_cli.core.domain.CommandDescriptor import CommandDescriptor
 
 _COMMAND_NAME = "help"
 _HELP_CONTENT = """
@@ -30,3 +31,4 @@ class HelpCommand(AbstractCommand):
 
     def execute_command(self, command_descriptor: CommandDescriptor) -> None:
         [print(line, end="") for line in self._help_text]
+        RuntimeHelper.exit_with_error_in_cicd_mode()

--- a/domino_cli/core/command/WizardCommand.py
+++ b/domino_cli/core/command/WizardCommand.py
@@ -1,3 +1,4 @@
+from domino_cli.core.cli.Logging import warning
 from domino_cli.core.command.AbstractCommand import AbstractCommand
 from domino_cli.core.domain.CommandDescriptor import CommandDescriptor
 from domino_cli.core.service.ConfigurationWizardService import ConfigurationWizardService
@@ -21,7 +22,7 @@ class WizardCommand(AbstractCommand):
         :param command_descriptor: CommandDescriptor object containing the command arguments
         """
         if not len(command_descriptor.arguments) == 1:
-            print("Wizard name required")
+            warning("Wizard name required")
             self._configuration_wizard_service.show_available_wizards()
         else:
             self._configuration_wizard_service.run_wizard(command_descriptor.arguments[0])

--- a/domino_cli/core/domain/OAuthConfig.py
+++ b/domino_cli/core/domain/OAuthConfig.py
@@ -1,5 +1,7 @@
 import os
 
+from domino_cli.core.cli.Logging import warning
+
 _OAUTH_TOKEN_URL = "DOMINO_OAUTH_TOKEN_URL"
 _OAUTH_CLIENT_ID = "DOMINO_OAUTH_CLIENT_ID"
 _OAUTH_CLIENT_SECRET = "DOMINO_OAUTH_CLIENT_SECRET"
@@ -38,7 +40,7 @@ class OAuthConfig:
         present: bool = True
         if OAuthConfig._get_parameter(parameter) is None:
             present = False
-            print(f"Parameter {parameter} is missing")
+            warning(f"Parameter {parameter} is missing")
 
         return present
 

--- a/domino_cli/core/service/AuthenticationService.py
+++ b/domino_cli/core/service/AuthenticationService.py
@@ -1,5 +1,7 @@
 from typing import List, Dict
 
+from domino_cli.core.cli.Logging import info, error
+from domino_cli.core.cli.RuntimeHelper import RuntimeHelper
 from domino_cli.core.domain.AuthMode import AuthMode
 from domino_cli.core.domain.SessionContext import SessionContext
 from domino_cli.core.service.SessionContextHolder import SessionContextHolder
@@ -18,15 +20,16 @@ class AuthenticationService:
         self._session_context_holder: SessionContextHolder = session_context_holder
         self._auth_handler_dict: Dict[AuthMode, AbstractAuthHandler] = self._init_handler_map(auth_handlers)
 
-        print(f"Domino authentication mode is set to {self._auth_mode.name}. Use 'auth --set-mode' command to change")
+        info(f"Domino authentication mode is set to {self._auth_mode.name}. Use 'auth --set-mode' command to change")
 
     def encrypt_password(self) -> None:
         """
         Utility to encrypt a password with BCrypt for usage in Domino (as service user password).
         """
+        RuntimeHelper.unsupported_in_cicd_mode()
         encrypted_password: str = encrypt(AuthUtils.input_password())
 
-        print("Encrypted password: {0}".format(encrypted_password))
+        info("Encrypted password: {0}".format(encrypted_password))
 
     def generate_token(self) -> None:
         """
@@ -35,22 +38,29 @@ class AuthenticationService:
         try:
             session_context: SessionContext = self._request_token()
 
-            print("Generated auth token: {0}".format(session_context.authentication_token))
+            if RuntimeHelper.is_cicd_mode():
+                print(session_context.authentication_token)
+            else:
+                info("Generated auth token: {0}".format(session_context.authentication_token))
+
         except Exception as exc:
-            print("Failed to generate token - reason: {0}".format(str(exc)))
+            error("Failed to generate token - reason: {0}".format(str(exc)))
+            RuntimeHelper.exit_with_error_in_cicd_mode()
 
     def open_session(self) -> None:
         """
         Opens an authenticated session for Domino CLI.
         This step is required before executing any lifecycle command, otherwise Domino rejects every request.
         """
+        RuntimeHelper.unsupported_in_cicd_mode()
         try:
             session_context: SessionContext = self._request_token()
             self._session_context_holder.update(session_context)
 
-            print("Session is open")
+            info("Session is open")
         except Exception as exc:
-            print("Failed to open session - reason: {0}".format(str(exc)))
+            error("Failed to open session - reason: {0}".format(str(exc)))
+            RuntimeHelper.exit_with_error_in_cicd_mode()
 
     def set_mode(self, new_mode: str) -> None:
         """
@@ -59,10 +69,11 @@ class AuthenticationService:
 
         :param new_mode: authentication mode to change to
         """
+        RuntimeHelper.unsupported_in_cicd_mode()
         try:
             self._auth_mode = AuthMode.by_value(new_mode)
         except KeyError:
-            print(f"Failed to change authentication mode, invalid mode defined: {new_mode}")
+            error(f"Failed to change authentication mode, invalid mode defined: {new_mode}")
 
     def _request_token(self) -> SessionContext:
 

--- a/domino_cli/core/service/CommandProcessor.py
+++ b/domino_cli/core/service/CommandProcessor.py
@@ -1,6 +1,7 @@
 import os
 from typing import List
 
+from domino_cli.core.cli.Logging import info
 from domino_cli.core.command.AbstractCommand import AbstractCommand
 from domino_cli.core.command.ExitCommand import ExitCommand
 from domino_cli.core.domain.CommandDescriptor import CommandDescriptor
@@ -27,7 +28,7 @@ class CommandProcessor:
         """
 
         if _DEBUG_MODE:
-            print("Command to be executed: {0}".format(command_descriptor))
+            info("Command to be executed: {0}".format(command_descriptor))
 
         command_iterator = filter(lambda command: command.is_applicable(command_descriptor), self._registered_commands)
         selected_command = next(command_iterator, self._default_command)

--- a/domino_cli/core/service/ConfigurationWizardService.py
+++ b/domino_cli/core/service/ConfigurationWizardService.py
@@ -1,5 +1,7 @@
 from typing import List, Dict
 
+from domino_cli.core.cli.Logging import warning, info
+from domino_cli.core.cli.RuntimeHelper import RuntimeHelper
 from domino_cli.core.service.wizard.AbstractWizard import AbstractWizard
 
 _WIZARD_HELP_TEXT_LINE = "{}\n[{:>15}]: {}"
@@ -17,7 +19,8 @@ class ConfigurationWizardService:
         """
         Prints the name and the description of the available wizards.
         """
-        print("Available wizards:{0}".format(self._available_wizards_help))
+        RuntimeHelper.unsupported_in_cicd_mode()
+        info("Available wizards:{0}".format(self._available_wizards_help))
 
     def run_wizard(self, wizard_name: str) -> None:
         """
@@ -25,8 +28,9 @@ class ConfigurationWizardService:
 
         :param wizard_name: name of the wizard to be executed
         """
+        RuntimeHelper.unsupported_in_cicd_mode()
         if wizard_name not in self._wizards.keys():
-            print("Unknown wizard '{0}'".format(wizard_name))
+            warning("Unknown wizard '{0}'".format(wizard_name))
             self.show_available_wizards()
         else:
             wizard: AbstractWizard = self._wizards.get(wizard_name)

--- a/domino_cli/core/service/SessionContextHolder.py
+++ b/domino_cli/core/service/SessionContextHolder.py
@@ -1,5 +1,7 @@
+import os
 from typing import Optional
 
+from domino_cli.core.cli.Logging import warning
 from domino_cli.core.domain.SessionContext import SessionContext
 
 
@@ -9,6 +11,10 @@ class SessionContextHolder:
     """
     def __init__(self):
         self._session_context = None
+
+        preauthorized_token = os.getenv("DOMINO_CLI_PREAUTHORIZED_TOKEN")
+        if preauthorized_token is not None:
+            self._session_context = SessionContext("preauthorized", preauthorized_token)
 
     def update(self, session_context: SessionContext) -> None:
         """
@@ -20,7 +26,7 @@ class SessionContextHolder:
 
         bearer_auth = None
         if self._session_context is None:
-            print("WARNING: Session is not yet open!")
+            warning("Session is not yet open!")
         else:
             bearer_auth = {"Authorization": "Bearer {0}".format(self._session_context.authentication_token)}
 

--- a/domino_cli/core/service/auth/AuthUtils.py
+++ b/domino_cli/core/service/auth/AuthUtils.py
@@ -1,6 +1,8 @@
 import os
 from getpass import getpass
 
+from domino_cli.core.cli.RuntimeHelper import RuntimeHelper
+
 _DOMINO_CLI_USERNAME = "DOMINO_CLI_USERNAME"
 _DOMINO_CLI_PASSWORD = "DOMINO_CLI_PASSWORD"
 
@@ -20,7 +22,7 @@ class AuthUtils:
         """
         username = os.getenv(_DOMINO_CLI_USERNAME)
         if username is None:
-            username = input(" ** specify username: ")
+            username = RuntimeHelper.input_wrapper(lambda: input(" ** specify username: "))
 
         return username
 
@@ -34,6 +36,6 @@ class AuthUtils:
         """
         password = os.getenv(_DOMINO_CLI_PASSWORD)
         if password is None:
-            password = getpass(" ** specify password: ")
+            password = RuntimeHelper.input_wrapper(lambda: getpass(" ** specify password: "))
 
         return password

--- a/domino_cli/core/service/wizard/installer/PlatformComponentInstaller.py
+++ b/domino_cli/core/service/wizard/installer/PlatformComponentInstaller.py
@@ -2,6 +2,8 @@ import subprocess
 from abc import ABC, abstractmethod
 from typing import List
 
+from domino_cli.core.cli.Logging import info, warning
+from domino_cli.core.cli.RuntimeHelper import RuntimeHelper
 from domino_cli.core.service.wizard.installer import VersionResolver
 from domino_cli.core.service.wizard.mapping.InstallerWizardDataMapping import Mapping
 from domino_cli.core.service.wizard.mapping.WizardDataMappingBaseEnum import WizardDataMappingBaseEnum
@@ -21,15 +23,15 @@ class PlatformComponentInstaller(ABC):
         :param wizard_data: raw wizard data to extract installation parameters from
         """
         component = self._extract_value(wizard_data, Mapping.COMPONENT)
-        print("Preparing to install {0} as {1} ...".format(component.value, self._reported_installation_method()))
-        print("Looking up latest version of component {0}, please wait ...".format(component.value))
+        info("Preparing to install {0} as {1} ...".format(component.value, self._reported_installation_method()))
+        info("Looking up latest version of component {0}, please wait ...".format(component.value))
         version = self._version_resolver.resolve_latest(component)
         command_lines = self._prepare_command_lines(component, wizard_data, version)
 
-        print("{0} {1} will be installed. Do you wish to proceed? (Type 'yes' to proceed)"
+        info("{0} {1} will be installed. Do you wish to proceed? (Type 'yes' to proceed)"
               .format(component.value, version))
-        if input() != "yes":
-            print("Installation aborted")
+        if RuntimeHelper.input_wrapper(lambda: input()) != "yes":
+            warning("Installation aborted")
             return
 
         [subprocess.call(command_line) for command_line in command_lines]

--- a/domino_cli/core/service/wizard/render/WizardResultConsoleRenderer.py
+++ b/domino_cli/core/service/wizard/render/WizardResultConsoleRenderer.py
@@ -1,5 +1,7 @@
 import yaml
 
+from domino_cli.core.cli.Logging import info
+
 
 class WizardResultConsoleRenderer:
     """
@@ -12,7 +14,8 @@ class WizardResultConsoleRenderer:
         :param result: target dictionary to be rendered
         """
         yaml_result = yaml.dump(result, sort_keys=False)
-        print("\nCopy the relevant part of the YAML document below in your Domino Platform component "
+        print()
+        info("Copy the relevant part of the YAML document below in your Domino Platform component "
               "instance's configuration file\n")
         print("# --- Configuration starts here ---\n")
         print(yaml_result)

--- a/domino_cli/core/service/wizard/render/WizardResultFileRenderer.py
+++ b/domino_cli/core/service/wizard/render/WizardResultFileRenderer.py
@@ -5,6 +5,8 @@ from typing import Callable
 
 import yaml
 
+from domino_cli.core.cli.RuntimeHelper import RuntimeHelper
+
 
 class WizardResultFileRenderer:
     """
@@ -19,7 +21,7 @@ class WizardResultFileRenderer:
         :param result: target dictionary to be rendered
         :param merge_node_selector_function: lambda function to select base node from where the merging should happen
         """
-        target_file: str = input("File path > ")
+        target_file: str = RuntimeHelper.input_wrapper(lambda: input("File path > "))
         to_write: dict = self._prepare_dict_to_write(target_file, result, merge_node_selector_function)
         with open(target_file, "w") as target_file:
             yaml.dump(to_write, target_file, sort_keys=False)

--- a/domino_cli/core/service/wizard/step/BaseWizardStep.py
+++ b/domino_cli/core/service/wizard/step/BaseWizardStep.py
@@ -1,5 +1,6 @@
 from typing import List, Callable
 
+from domino_cli.core.cli.RuntimeHelper import RuntimeHelper
 from domino_cli.core.service.wizard.mapping.WizardDataMappingBaseEnum import WizardDataMappingBaseEnum
 from domino_cli.core.service.wizard.step.WizardStep import WizardStep, WizardStepTransition
 
@@ -38,7 +39,7 @@ class BaseWizardStep(WizardStep):
         """
         See documentation of WizardStep.
         """
-        answer: str = input()
+        answer: str = RuntimeHelper.input_wrapper(lambda: input())
         result[self.get_step_id()] = self._default_answer \
             if len(answer) == 0 \
             else answer

--- a/domino_cli/core/service/wizard/step/KeyValuePairAnswerWizardStep.py
+++ b/domino_cli/core/service/wizard/step/KeyValuePairAnswerWizardStep.py
@@ -1,3 +1,5 @@
+from domino_cli.core.cli.Logging import warning
+from domino_cli.core.cli.RuntimeHelper import RuntimeHelper
 from domino_cli.core.service.wizard.mapping.WizardDataMappingBaseEnum import WizardDataMappingBaseEnum
 from domino_cli.core.service.wizard.step.BaseWizardStep import BaseWizardStep
 
@@ -18,13 +20,13 @@ class KeyValuePairAnswerWizardStep(BaseWizardStep):
         """
         result[self.get_step_id()] = dict()
         while True:
-            current_answer: str = input()
+            current_answer: str = RuntimeHelper.input_wrapper(lambda: input())
             if len(current_answer) > 0:
                 split_answer = current_answer.split(sep=":", maxsplit=1)
                 try:
                     result[self.get_step_id()][split_answer[0]] = split_answer[1]
                 except IndexError:
-                    print("Invalid format - please specify your answer in key:value format")
+                    warning("Invalid format - please specify your answer in key:value format")
                     continue
             else:
                 break

--- a/domino_cli/core/service/wizard/step/MultiAnswerWizardStep.py
+++ b/domino_cli/core/service/wizard/step/MultiAnswerWizardStep.py
@@ -1,3 +1,4 @@
+from domino_cli.core.cli.RuntimeHelper import RuntimeHelper
 from domino_cli.core.service.wizard.mapping.WizardDataMappingBaseEnum import WizardDataMappingBaseEnum
 from domino_cli.core.service.wizard.step.BaseWizardStep import BaseWizardStep
 
@@ -17,7 +18,7 @@ class MultiAnswerWizardStep(BaseWizardStep):
         """
         result[self.get_step_id()] = []
         while True:
-            current_answer: str = input()
+            current_answer: str = RuntimeHelper.input_wrapper(lambda: input())
             if len(current_answer) > 0:
                 result[self.get_step_id()].append(current_answer)
             else:

--- a/domino_cli/core/service/wizard/step/OptionSelectorWizardStep.py
+++ b/domino_cli/core/service/wizard/step/OptionSelectorWizardStep.py
@@ -1,5 +1,6 @@
 from typing import List
 
+from domino_cli.core.cli.Logging import warning
 from domino_cli.core.service.wizard.mapping.WizardDataMappingBaseEnum import WizardDataMappingBaseEnum
 from domino_cli.core.service.wizard.step.BaseWizardStep import BaseWizardStep
 
@@ -44,7 +45,7 @@ class OptionSelectorWizardStep(BaseWizardStep):
             result[self.get_step_id()] = self.get_options()[index]
 
         except (IndexError, ValueError):
-            print("Your choice is invalid - please try again")
+            warning("Your choice is invalid - please try again")
             self.read_answer(result)
 
     def __repr__(self):

--- a/tests/core/command/test_DeployApplicationCommand.py
+++ b/tests/core/command/test_DeployApplicationCommand.py
@@ -48,7 +48,7 @@ class DeployApplicationCommandTest(CommandBaseTest):
 
         # then
         self.assertEqual(self.domino_service_mock.call_count, 0)
-        print_mock.assert_called_once_with("Application name and 'latest' keyword or explicit version is required")
+        print_mock.assert_called_once_with("[warn ] Application name and 'latest' keyword or explicit version is required")
 
     def test_should_command_be_applicable_for_deploy_command(self):
 

--- a/tests/core/command/test_ExitCommand.py
+++ b/tests/core/command/test_ExitCommand.py
@@ -21,7 +21,7 @@ class ExitCommandTest(CommandBaseTest):
         self.exit_command.execute_command(command_descriptor)
 
         # then
-        print_mock.assert_called_once_with("Bye!")
+        print_mock.assert_called_once_with("[info ] Bye!")
 
     def test_should_command_be_applicable_for_exit_command(self):
 

--- a/tests/core/command/test_InfoCommand.py
+++ b/tests/core/command/test_InfoCommand.py
@@ -37,7 +37,7 @@ class InfoCommandTest(CommandBaseTest):
 
         # then
         self.assertEqual(self.domino_service_mock.call_count, 0)
-        print_mock.assert_called_once_with("Application name required")
+        print_mock.assert_called_once_with("[warn ] Application name required")
 
     def test_should_command_be_applicable_for_info_command(self):
 

--- a/tests/core/command/test_RestartApplicationCommand.py
+++ b/tests/core/command/test_RestartApplicationCommand.py
@@ -37,7 +37,7 @@ class RestartApplicationCommandTest(CommandBaseTest):
 
         # then
         self.assertEqual(self.domino_service_mock.call_count, 0)
-        print_mock.assert_called_once_with("Application name required")
+        print_mock.assert_called_once_with("[warn ] Application name required")
 
     def test_should_command_be_applicable_for_restart_command(self):
 

--- a/tests/core/command/test_StartApplicationCommand.py
+++ b/tests/core/command/test_StartApplicationCommand.py
@@ -37,7 +37,7 @@ class StartApplicationCommandTest(CommandBaseTest):
 
         # then
         self.assertEqual(self.domino_service_mock.call_count, 0)
-        print_mock.assert_called_once_with("Application name required")
+        print_mock.assert_called_once_with("[warn ] Application name required")
 
     def test_should_command_be_applicable_for_start_command(self):
 

--- a/tests/core/command/test_StopApplicationCommand.py
+++ b/tests/core/command/test_StopApplicationCommand.py
@@ -37,7 +37,7 @@ class StopApplicationCommandTest(CommandBaseTest):
 
         # then
         self.assertEqual(self.domino_service_mock.call_count, 0)
-        print_mock.assert_called_once_with("Application name required")
+        print_mock.assert_called_once_with("[warn ] Application name required")
 
     def test_should_command_be_applicable_for_stop_command(self):
 

--- a/tests/core/command/test_WizardCommand.py
+++ b/tests/core/command/test_WizardCommand.py
@@ -35,7 +35,7 @@ class WizardCommandTest(CommandBaseTest):
         self.wizard_command.execute_command(command_descriptor)
 
         # then
-        print_mock.assert_called_once_with("Wizard name required")
+        print_mock.assert_called_once_with("[warn ] Wizard name required")
         self.assertEqual(self.configuration_wizard_service_mock.show_available_wizards.call_count, 1)
         self.assertEqual(self.configuration_wizard_service_mock.run_wizard.call_count, 0)
 

--- a/tests/core/service/test_AuthenticationService.py
+++ b/tests/core/service/test_AuthenticationService.py
@@ -64,7 +64,7 @@ class AuthenticationServiceTest(unittest.TestCase):
         self.authentication_service.generate_token()
 
         # then
-        self.assertEqual(AuthenticationServiceTest._extract_print_value(print_mock), "Generated auth token: jwt_token")
+        self.assertEqual(AuthenticationServiceTest._extract_print_value(print_mock), "[info ] Generated auth token: jwt_token")
 
     @mock.patch("builtins.print", side_effect=print)
     @mock.patch("builtins.input", return_value=_TEST_USERNAME)
@@ -78,7 +78,7 @@ class AuthenticationServiceTest(unittest.TestCase):
         self.authentication_service.generate_token()
 
         # then
-        self.assertEqual(AuthenticationServiceTest._extract_print_value(print_mock), "Failed to generate token - reason: Failed to authenticate")
+        self.assertEqual(AuthenticationServiceTest._extract_print_value(print_mock), "[error] Failed to generate token - reason: Failed to authenticate")
 
     @mock.patch("builtins.print", side_effect=print)
     @mock.patch("builtins.input", return_value=_TEST_USERNAME)
@@ -92,7 +92,7 @@ class AuthenticationServiceTest(unittest.TestCase):
         self.authentication_service.open_session()
 
         # then
-        self.assertEqual(AuthenticationServiceTest._extract_print_value(print_mock), "Session is open")
+        self.assertEqual(AuthenticationServiceTest._extract_print_value(print_mock), "[info ] Session is open")
         self.assertEqual(self.session_context_holder_mock.update.call_count, 1)
         session_context: SessionContext = self._extract_session_context()
         self.assertEqual(session_context.username, _TEST_USERNAME)
@@ -110,7 +110,7 @@ class AuthenticationServiceTest(unittest.TestCase):
         self.authentication_service.open_session()
 
         # then
-        self.assertEqual(AuthenticationServiceTest._extract_print_value(print_mock), "Failed to open session - reason: Failed to authenticate")
+        self.assertEqual(AuthenticationServiceTest._extract_print_value(print_mock), "[error] Failed to open session - reason: Failed to authenticate")
         self.assertEqual(self.session_context_holder_mock.call_count, 0)
 
     def test_should_set_mode_to_direct(self):
@@ -137,7 +137,7 @@ class AuthenticationServiceTest(unittest.TestCase):
 
         # then
         self.assertEqual(self.authentication_service._auth_mode, AuthMode.DIRECT)
-        self.assertEqual(AuthenticationServiceTest._extract_print_value(print_mock), "Failed to change authentication mode, invalid mode defined: invalid")
+        self.assertEqual(AuthenticationServiceTest._extract_print_value(print_mock), "[error] Failed to change authentication mode, invalid mode defined: invalid")
 
     def _extract_session_context(self):
         return self.session_context_holder_mock.mock_calls[0][1][0]

--- a/tests/core/service/test_ConfigurationWizardService.py
+++ b/tests/core/service/test_ConfigurationWizardService.py
@@ -4,7 +4,7 @@ from unittest import mock
 from domino_cli.core.service.ConfigurationWizardService import ConfigurationWizardService
 from domino_cli.core.service.wizard.AbstractWizard import AbstractWizard
 
-_AVAILABLE_WIZARDS_EXPECTED_HELP = "Available wizards:\n[           wiz1]: wiz1_desc\n[           wiz2]: wiz2_desc"
+_AVAILABLE_WIZARDS_EXPECTED_HELP = "[info ] Available wizards:\n[           wiz1]: wiz1_desc\n[           wiz2]: wiz2_desc"
 
 
 class ConfigurationWizardServiceTest(unittest.TestCase):
@@ -47,7 +47,7 @@ class ConfigurationWizardServiceTest(unittest.TestCase):
 
         # then
         print_mock.assert_has_calls([
-            mock.call("Unknown wizard 'non-existing-wizard'"),
+            mock.call("[warn ] Unknown wizard 'non-existing-wizard'"),
             mock.call(_AVAILABLE_WIZARDS_EXPECTED_HELP)
         ])
         self.assertEqual(self.abstract_wizard_1.run.call_count, 0)

--- a/tests/core/service/test_DominoService.py
+++ b/tests/core/service/test_DominoService.py
@@ -28,11 +28,11 @@ class DominoServiceTest(unittest.TestCase):
         self._assert_client_call("/lifecycle/app1/deploy/1.0.0")
         self.assertEqual(print_mock.call_count, 6)
         print_mock.assert_has_calls([
-            mock.call("Sending DEPLOY_VERSION command for application app1 via Domino"),
-            mock.call("Command DEPLOY_VERSION successfully executed on application app1"),
-            mock.call(" --- Response details ---"),
-            mock.call("   message: some details"),
-            mock.call("    status: ALL_OK"),
+            mock.call("[info ] Sending DEPLOY_VERSION command for application app1 via Domino"),
+            mock.call("[info ] Command DEPLOY_VERSION successfully executed on application app1"),
+            mock.call("[info ]  --- Response details ---"),
+            mock.call("[info ]              message: some details"),
+            mock.call("[info ]               status: ALL_OK"),
             mock.call()
         ])
 
@@ -48,8 +48,8 @@ class DominoServiceTest(unittest.TestCase):
         # then
         self._assert_client_call("/lifecycle/app2/start")
         print_mock.assert_has_calls([
-            mock.call("Sending START command for application app2 via Domino"),
-            mock.call("Failed to execute command START on application app2 - Domino responded with 500")
+            mock.call("[info ] Sending START command for application app2 via Domino"),
+            mock.call("[error] Failed to execute command START on application app2 - Domino responded with 500")
         ])
 
     @mock.patch("builtins.print", side_effect=print)
@@ -64,8 +64,8 @@ class DominoServiceTest(unittest.TestCase):
         # then
         self._assert_client_call("/lifecycle/app3/stop", expected_method=HTTPMethod.DELETE)
         print_mock.assert_has_calls([
-            mock.call("Sending STOP command for application app3 via Domino"),
-            mock.call("Failed to execute HTTP request [DELETE /lifecycle/app3/stop] - reason Mock client call failure")
+            mock.call("[info ] Sending STOP command for application app3 via Domino"),
+            mock.call("[error] Failed to execute HTTP request [DELETE /lifecycle/app3/stop] - reason Mock client call failure")
         ])
 
     def _assert_client_call(self, expected_path, expected_method=HTTPMethod.PUT):

--- a/tests/core/service/test_SessionContextHolder.py
+++ b/tests/core/service/test_SessionContextHolder.py
@@ -18,7 +18,7 @@ class SessionContextHolderTest(unittest.TestCase):
 
         # then
         self.assertIsNone(result)
-        print_mock.assert_called_once_with("WARNING: Session is not yet open!")
+        print_mock.assert_called_once_with("[warn ] Session is not yet open!")
 
     def test_should_get_bearer_auth_return_authorization_header_after_updating_context(self):
 

--- a/tests/core/service/wizard/render/test_WizardResultConsoleRenderer.py
+++ b/tests/core/service/wizard/render/test_WizardResultConsoleRenderer.py
@@ -19,7 +19,7 @@ class WizardResultConsoleRendererTest(unittest.TestCase):
         self.wizard_result_console_renderer.render(source_dict)
 
         # then
-        self.assertEqual(print_mock.call_count, 4)
+        self.assertEqual(print_mock.call_count, 5)
         print_mock.assert_has_calls([
             mock.call("root:\n  key_b: true\n  key_a: value\n  key_c: 1234\n")
         ])


### PR DESCRIPTION
 - Implemented CI/CD runtime mode handling
 - Added capability to pass a preauthorized token to the tool (for CI/CD mode)
 - Improved terminal output messages
 - Aligned affected unit tests
 - Updated documentation
 - Bumped version to 2.2.0