### PR TITLE
LFLT-656 Make Domino support multi-instance deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,31 +140,36 @@ The commands below work only in case the proper application registrations have a
 The `app` parameter of the commands always refer to an application's registered identifier.
 
 ```
-deploy <app> <latest|version>
+deploy <app> <latest|version> [--roll|--instance <instance-suffix>]
 ```
 Instructs Domino to deploy the specified version of the given application. The application and its selected version 
 must be already uploaded to the target server via Domino. Specify the keyword `latest` to let Domino decide which 
-version to be deployed, or provide an existing version number of the application.
+version to be deployed, or provide an existing version number of the application. Passing the `--roll` switch instructs
+Domino to automatically deploy and auto-start all instances of a multi-instance deployment, while 
+`--instance <instance-suffix>` can be used to deploy only the selected single instance of a multi-instance deployment 
+(auto-start is not applicable in this case). Neither of these switches are available for single-instance deployments.
 
 ```
-start <app>
+start <app> [--roll|--instance <instance-suffix>]
 ```
-Instructs Domino to start the currently deployed version of the application.
+Instructs Domino to start the currently deployed version of the application. The `--roll` switch can be used to 
+start/stop/restart all available instances of a multi-instance deployment, while `--instance <instance-suffix>` can be
+used to start/stop/restart only the specified instance of a multi-instance deployment.
 
 ```
-stop <app>
+stop <app> [--roll|--instance <instance-suffix>]
 ```
 Instructs Domino to stop the currently running instance of the application.
 
 ```
-restart <app>
+restart <app> [--roll|--instance <instance-suffix>]
 ```
 Instructs Domino to restart the currently running instance of the application.
 
 ```
-info <app>
+info <app> [--instance <instance-suffix>]
 ```
-Instructs Domino to query the application's info endpoint and returns the results.
+Instructs Domino to query the application's info endpoint and returns the results. 
 
 ### Deployment definition management commands
 

--- a/domino_cli/__init__.py
+++ b/domino_cli/__init__.py
@@ -2,7 +2,7 @@
 domino_cli.py :: Main entry point for Domino CLI application.
 """
 
-__version__ = "2.5.0"
+__version__ = "2.6.0"
 
 from domino_cli.core.ApplicationContext import ApplicationContext
 

--- a/domino_cli/core/command/AbstractLifecycleCommand.py
+++ b/domino_cli/core/command/AbstractLifecycleCommand.py
@@ -17,11 +17,19 @@ class AbstractLifecycleCommand(AbstractCommand):
     def execute_command(self, command_descriptor: CommandDescriptor) -> None:
         """
         Executes a simple lifecycle command (currently supported commands are start, stop, restart).
-        Argument array should only contain the name of the application.
+        Argument array must contain the name of the application. Besides, --roll and --instance flags can be used to
+        trigger rolling all instances of a multi-instance deployment or just a specific instance, respectively.
 
         :param command_descriptor: CommandDescriptor object containing the command arguments
         """
-        if not len(command_descriptor.arguments) == 1:
+        if len(command_descriptor.arguments) == 0:
             warning("Application name required")
         else:
-            self._domino_service.execute_lifecycle_command(self._domino_command, command_descriptor.arguments[0])
+
+            roll = "--roll" in command_descriptor.arguments
+            instance = command_descriptor.arguments[2] \
+                if "--instance" in command_descriptor.arguments and len(command_descriptor.arguments) == 3 \
+                else None
+
+            self._domino_service.execute_lifecycle_command(self._domino_command, command_descriptor.arguments[0],
+                                                           version=None, roll=roll, instance=instance)

--- a/domino_cli/core/command/DeployApplicationCommand.py
+++ b/domino_cli/core/command/DeployApplicationCommand.py
@@ -26,7 +26,7 @@ class DeployApplicationCommand(AbstractCommand):
 
         :param command_descriptor: CommandDescriptor object containing the command arguments
         """
-        if not len(command_descriptor.arguments) == 2:
+        if len(command_descriptor.arguments) < 2:
             error("Application name and 'latest' keyword or explicit version is required")
             RuntimeHelper.exit_with_error_in_cicd_mode()
 
@@ -37,4 +37,9 @@ class DeployApplicationCommand(AbstractCommand):
                 if version == _LATEST_KEYWORD \
                 else DominoCommand.DEPLOY_VERSION
 
-            self._domino_service.execute_lifecycle_command(command, application, version)
+            roll = "--roll" in command_descriptor.arguments
+            instance = command_descriptor.arguments[3] \
+                if "--instance" in command_descriptor.arguments and len(command_descriptor.arguments) == 4 \
+                else None
+
+            self._domino_service.execute_lifecycle_command(command, application, version, roll, instance)

--- a/domino_cli/core/service/DominoService.py
+++ b/domino_cli/core/service/DominoService.py
@@ -16,17 +16,23 @@ class DominoService:
     def __init__(self, domino_client: DominoClient):
         self._domino_client = domino_client
 
-    def execute_lifecycle_command(self, domino_command: DominoCommand, application: str, version: str = None) -> None:
+    def execute_lifecycle_command(self, domino_command: DominoCommand, application: str, version: str | None = None, roll: bool = False, instance: str | None = None) -> None:
         """
         Executes the given lifecycle command for the given application.
 
         :param domino_command: DominoCommand object specifying the command to be executed
         :param application: application name to send the command to
-        :param version: optional version number
+        :param version: (optional) version number
+        :param roll: instructs Domino to roll the application instances of multi-instance deployments
+        :param instance: instructs Domino to only apply the command to a specific instance of a multi-instance deployment
         """
+        query: dict[str, str] = {"roll": "true" if roll else "false"}
+        if instance:
+            query["instance"] = instance
+
         domino_request_descriptor: DominoRequestDescriptor = domino_command.value
         formatted_path = domino_request_descriptor.path_template.format(application, version)
-        domino_request = DominoRequest(domino_request_descriptor.method, formatted_path, authenticated=True)
+        domino_request = DominoRequest(domino_request_descriptor.method, formatted_path, authenticated=True, query=query)
 
         info("Sending {0} command for application {1} via Domino".format(domino_command.name, application))
 
@@ -48,7 +54,7 @@ class DominoService:
 
     def import_definition(self, optional_definition_path: str | None = None) -> None:
         """
-        Imports the given deployment definition. If path is not provided, defaults to ".domino/deployment.yml".
+        Imports the given deployment definition. If a path is not provided, defaults to ".domino/deployment.yml".
 
         :param optional_definition_path: optional path to a deployment definition
         """
@@ -80,7 +86,7 @@ class DominoService:
 
     def import_oauth_descriptor(self, application: str, dry_run: bool, optional_descriptor_path: str | None = None) -> None:
         """
-        Imports the given OAuth descriptor. If path is not provided, defaults to ".domino/oauth.yml".
+        Imports the given OAuth descriptor. If a path is not provided, defaults to ".domino/oauth.yml".
 
         :param application: name of the application name to submit the OAuth descriptor for
         :param dry_run: do not execute actual changes (verifies the descriptor and the relations defined by it, without saving it)

--- a/domino_cli/core/service/wizard/DeploymentConfigWizard.py
+++ b/domino_cli/core/service/wizard/DeploymentConfigWizard.py
@@ -11,6 +11,8 @@ from domino_cli.core.service.wizard.transformer.AbstractWizardResultTransformer 
 _WIZARD_NAME = "deployment"
 _WIZARD_DESCRIPTION = "Creates a properly configured Domino application deployment"
 _AVAILABLE_SOURCE_TYPES = ["filesystem", "docker"]
+_AVAILABLE_SPREAD_MODES = ["replicate", "one-per-host"]
+_AVAILABLE_NAMING_STRATEGIES = ["incremental-suffix", "custom-predefined"]
 _AVAILABLE_EXEC_TYPES = ["executable", "runtime", "service"]
 _AVAILABLE_DOCKER_EXEC_TYPES = ["standard"]
 _AVAILABLE_RESULT_RENDERERS = ["console", "file"]
@@ -35,6 +37,13 @@ class DeploymentConfigWizard(AbstractWizard):
         ws_deployment_name = BaseWizardStep(Mapping.DEPLOYMENT_NAME, "Specify an identifier for the deployment (e.g. abbreviation of app)")
         ws_source_type = OptionSelectorWizardStep(Mapping.SOURCE_TYPE, "Application will be filesystem or Docker based?", _AVAILABLE_SOURCE_TYPES)
         ws_target_hosts = MultiAnswerWizardStep(Mapping.TARGET_HOSTS, "Hosts to deploy application to (host IDs)")
+        ws_multi_instance = OptionSelectorWizardStep(Mapping.MULTI_INSTANCE_ENABLE, "Do you want to configure the application as multi-instance?")
+        ws_instance_count = BaseWizardStep(Mapping.INSTANCE_COUNT, "Specify the number of instances to be deployed")
+        ws_spread_mode = OptionSelectorWizardStep(Mapping.SPREAD_MODE, "Specify the spread mode", _AVAILABLE_SPREAD_MODES)
+        ws_naming_strategy = OptionSelectorWizardStep(Mapping.NAMING_STRATEGY, "Specify the naming strategy", _AVAILABLE_NAMING_STRATEGIES)
+        ws_defined_names = MultiAnswerWizardStep(Mapping.DEFINED_NAMES, "Specify the names of the instances")
+        ws_port_offset = BaseWizardStep(Mapping.PORT_OFFSET, "Specify the port offset")
+        ws_host_network_base_port = BaseWizardStep(Mapping.HOST_NETWORK_BASE_PORT, "Specify the base port for host network mode")
         ws_exec_type = OptionSelectorWizardStep(Mapping.EXEC_TYPE, "Specify the execution type", _AVAILABLE_EXEC_TYPES)
         ws_exec_type_docker = OptionSelectorWizardStep(Mapping.EXEC_TYPE, "Specify the Docker execution type", _AVAILABLE_DOCKER_EXEC_TYPES)
         ws_home = BaseWizardStep(Mapping.SOURCE_HOME, "What will be the home directory of the application?")
@@ -63,13 +72,26 @@ class DeploymentConfigWizard(AbstractWizard):
         ws_result_rendering = OptionSelectorWizardStep(Mapping.RESULT_RENDERING, "Write result to", _AVAILABLE_RESULT_RENDERERS)
 
         source_type_field = Mapping.SOURCE_TYPE.get_wizard_field()
+        multi_instance_enabled = Mapping.MULTI_INSTANCE_ENABLE.get_wizard_field()
+        naming_strategy_field = Mapping.NAMING_STRATEGY.get_wizard_field()
         exec_type_field = Mapping.EXEC_TYPE.get_wizard_field()
         health_check_enable_field = Mapping.HEALTH_CHECK_ENABLE.get_wizard_field()
         info_enable_field = Mapping.INFO_ENABLE.get_wizard_field()
 
         # transitions
         ws_deployment_name.add_transition(ws_target_hosts)
-        ws_target_hosts.add_transition(ws_source_type)
+
+        ws_target_hosts.add_transition(ws_multi_instance)
+        ws_multi_instance.add_transition(ws_instance_count, lambda context: context[multi_instance_enabled] == "yes")
+        ws_multi_instance.add_transition(ws_source_type, lambda context: context[multi_instance_enabled] == "no")
+        ws_instance_count.add_transition(ws_spread_mode)
+        ws_spread_mode.add_transition(ws_naming_strategy)
+        ws_naming_strategy.add_transition(ws_defined_names, lambda context: context[naming_strategy_field] == _AVAILABLE_NAMING_STRATEGIES[1])
+        ws_naming_strategy.add_transition(ws_port_offset, lambda context: context[naming_strategy_field] == _AVAILABLE_NAMING_STRATEGIES[0])
+        ws_defined_names.add_transition(ws_port_offset)
+        ws_port_offset.add_transition(ws_host_network_base_port)
+        ws_host_network_base_port.add_transition(ws_source_type)
+
         ws_source_type.add_transition(ws_exec_type, lambda context: context[source_type_field] == _AVAILABLE_SOURCE_TYPES[0])
         ws_source_type.add_transition(ws_exec_type_docker, lambda context: context[source_type_field] == _AVAILABLE_SOURCE_TYPES[1])
         ws_exec_type.add_transition(ws_home)

--- a/domino_cli/core/service/wizard/mapping/DeploymentConfigWizardDataMapping.py
+++ b/domino_cli/core/service/wizard/mapping/DeploymentConfigWizardDataMapping.py
@@ -10,6 +10,7 @@ class MappingGroups(Enum):
     HEALTH_CHECK = "healthcheck"
     INFO = "info"
     SOURCE_COMMON = "source-common"
+    MULTI_INSTANCE = "multi-instance"
 
 
 class Mapping(WizardDataMappingBaseEnum):
@@ -23,6 +24,15 @@ class Mapping(WizardDataMappingBaseEnum):
 
     SOURCE_HOME = (MappingGroups.SOURCE_COMMON, "src_home", "$root.source.home")
     BINARY_NAME = (MappingGroups.SOURCE_COMMON, "src_bin_name", "$root.source.resource")
+
+    MULTI_INSTANCE_ENABLE = (MappingGroups.BASE, "multi_instance_enable", "$root.target.multi-instance.enabled", _DEFAULT_OPTIONS_TO_BOOLEAN_MAPPER)
+    INSTANCE_COUNT = (MappingGroups.MULTI_INSTANCE, "instance_count", "$root.target.multi-instance.instance-count", _STR_TO_INT_MAPPER)
+    SPREAD_MODE = (MappingGroups.MULTI_INSTANCE, "spread_mode", "$root.target.multi-instance.spread-mode")
+    NAMING_STRATEGY = (MappingGroups.MULTI_INSTANCE, "naming_strategy", "$root.target.multi-instance.naming-strategy")
+    DEFINED_NAMES = (MappingGroups.MULTI_INSTANCE, "defined_names", "$root.target.multi-instance.defined-names")
+    PORT_OFFSET = (MappingGroups.MULTI_INSTANCE, "port_offset", "$root.target.multi-instance.port-offset", _STR_TO_INT_MAPPER)
+    HOST_NETWORK_BASE_PORT = (MappingGroups.MULTI_INSTANCE, "host_network_base_port", "$root.target.multi-instance.host-network-base-port", _STR_TO_INT_MAPPER)
+
     RUNTIME_NAME = ("", "runtime_name", "$root.runtime")
     EXEC_COMMAND_NAME = ("", "exec_cmd_name", "$root.execution.command-name")
     EXEC_USER = ("", "exec_user", "$root.execution.as-user")

--- a/domino_cli/core/service/wizard/transformer/DeploymentConfigWizardResultTransformer.py
+++ b/domino_cli/core/service/wizard/transformer/DeploymentConfigWizardResultTransformer.py
@@ -46,6 +46,8 @@ class DeploymentConfigWizardResultTransformer(AbstractWizardResultTransformer):
 
         target_dict: dict = {}
         [self._assign(mapping, root_node, source, target_dict) for mapping in Mapping.get_mappings_by_group(MappingGroups.BASE)]
+        if self._read_current_value(Mapping.MULTI_INSTANCE_ENABLE, root_node, target_dict):
+            [self._assign(mapping, root_node, source, target_dict) for mapping in Mapping.get_mappings_by_group(MappingGroups.MULTI_INSTANCE)]
 
         return target_dict
 

--- a/tests/core/command/test_DeployApplicationCommand.py
+++ b/tests/core/command/test_DeployApplicationCommand.py
@@ -24,7 +24,7 @@ class DeployApplicationCommandTest(CommandBaseTest):
         self.deploy_application_command.execute_command(command_descriptor)
 
         # then
-        self.domino_service_mock.execute_lifecycle_command.assert_called_once_with(DominoCommand.DEPLOY_LATEST, "app1", "latest")
+        self.domino_service_mock.execute_lifecycle_command.assert_called_once_with(DominoCommand.DEPLOY_LATEST, "app1", "latest", False, None)
 
     def test_should_execute_command_for_specified_version(self):
 
@@ -35,7 +35,29 @@ class DeployApplicationCommandTest(CommandBaseTest):
         self.deploy_application_command.execute_command(command_descriptor)
 
         # then
-        self.domino_service_mock.execute_lifecycle_command.assert_called_once_with(DominoCommand.DEPLOY_VERSION, "app1", "1.0.0")
+        self.domino_service_mock.execute_lifecycle_command.assert_called_once_with(DominoCommand.DEPLOY_VERSION, "app1", "1.0.0", False, None)
+
+    def test_should_execute_command_for_specified_version_and_rolling_deploy(self):
+
+        # given
+        command_descriptor: CommandDescriptor = CommandDescriptor("deploy app1 1.0.0 --roll")
+
+        # when
+        self.deploy_application_command.execute_command(command_descriptor)
+
+        # then
+        self.domino_service_mock.execute_lifecycle_command.assert_called_once_with(DominoCommand.DEPLOY_VERSION, "app1", "1.0.0", True, None)
+
+    def test_should_execute_command_for_specified_version_and_instance_deploy(self):
+
+        # given
+        command_descriptor: CommandDescriptor = CommandDescriptor("deploy app1 1.0.0 --instance 1")
+
+        # when
+        self.deploy_application_command.execute_command(command_descriptor)
+
+        # then
+        self.domino_service_mock.execute_lifecycle_command.assert_called_once_with(DominoCommand.DEPLOY_VERSION, "app1", "1.0.0", False, "1")
 
     @mock.patch("builtins.print", side_effect=print)
     def test_should_execute_command_fail_on_validation(self, print_mock):

--- a/tests/core/command/test_InfoCommand.py
+++ b/tests/core/command/test_InfoCommand.py
@@ -24,7 +24,7 @@ class InfoCommandTest(CommandBaseTest):
         self.info_command.execute_command(command_descriptor)
 
         # then
-        self.domino_service_mock.execute_lifecycle_command.assert_called_once_with(DominoCommand.INFO, "app1")
+        self.domino_service_mock.execute_lifecycle_command.assert_called_once_with(DominoCommand.INFO, "app1", None, False, None)
 
     @mock.patch("builtins.print", side_effect=print)
     def test_should_execute_command_fail_on_validation(self, print_mock):

--- a/tests/core/command/test_RestartApplicationCommand.py
+++ b/tests/core/command/test_RestartApplicationCommand.py
@@ -24,7 +24,29 @@ class RestartApplicationCommandTest(CommandBaseTest):
         self.restart_application_command.execute_command(command_descriptor)
 
         # then
-        self.domino_service_mock.execute_lifecycle_command.assert_called_once_with(DominoCommand.RESTART, "app1")
+        self.domino_service_mock.execute_lifecycle_command.assert_called_once_with(DominoCommand.RESTART, "app1", None, False, None)
+
+    def test_should_execute_command_for_rolling_restart_with_success(self):
+
+        # given
+        command_descriptor: CommandDescriptor = CommandDescriptor("restart app1 --roll")
+
+        # when
+        self.restart_application_command.execute_command(command_descriptor)
+
+        # then
+        self.domino_service_mock.execute_lifecycle_command.assert_called_once_with(DominoCommand.RESTART, "app1", None, True, None)
+
+    def test_should_execute_command_for_instance_restart_with_success(self):
+
+        # given
+        command_descriptor: CommandDescriptor = CommandDescriptor("restart app1 --instance primary")
+
+        # when
+        self.restart_application_command.execute_command(command_descriptor)
+
+        # then
+        self.domino_service_mock.execute_lifecycle_command.assert_called_once_with(DominoCommand.RESTART, "app1", None, False, "primary")
 
     @mock.patch("builtins.print", side_effect=print)
     def test_should_execute_command_fail_on_validation(self, print_mock):

--- a/tests/core/command/test_StartApplicationCommand.py
+++ b/tests/core/command/test_StartApplicationCommand.py
@@ -24,7 +24,29 @@ class StartApplicationCommandTest(CommandBaseTest):
         self.start_application_command.execute_command(command_descriptor)
 
         # then
-        self.domino_service_mock.execute_lifecycle_command.assert_called_once_with(DominoCommand.START, "app1")
+        self.domino_service_mock.execute_lifecycle_command.assert_called_once_with(DominoCommand.START, "app1", None, False, None)
+
+    def test_should_execute_command_for_rolling_start_with_success(self):
+
+        # given
+        command_descriptor: CommandDescriptor = CommandDescriptor("start app1 --roll")
+
+        # when
+        self.start_application_command.execute_command(command_descriptor)
+
+        # then
+        self.domino_service_mock.execute_lifecycle_command.assert_called_once_with(DominoCommand.START, "app1", None, True, None)
+
+    def test_should_execute_command_for_instance_start_with_success(self):
+
+        # given
+        command_descriptor: CommandDescriptor = CommandDescriptor("start app1 --instance primary")
+
+        # when
+        self.start_application_command.execute_command(command_descriptor)
+
+        # then
+        self.domino_service_mock.execute_lifecycle_command.assert_called_once_with(DominoCommand.START, "app1", None, False, "primary")
 
     @mock.patch("builtins.print", side_effect=print)
     def test_should_execute_command_fail_on_validation(self, print_mock):

--- a/tests/core/command/test_StopApplicationCommand.py
+++ b/tests/core/command/test_StopApplicationCommand.py
@@ -24,7 +24,29 @@ class StopApplicationCommandTest(CommandBaseTest):
         self.stop_application_command.execute_command(command_descriptor)
 
         # then
-        self.domino_service_mock.execute_lifecycle_command.assert_called_once_with(DominoCommand.STOP, "app1")
+        self.domino_service_mock.execute_lifecycle_command.assert_called_once_with(DominoCommand.STOP, "app1", None, False, None)
+
+    def test_should_execute_command_for_rolling_stop_with_success(self):
+
+        # given
+        command_descriptor: CommandDescriptor = CommandDescriptor("stop app1 --roll")
+
+        # when
+        self.stop_application_command.execute_command(command_descriptor)
+
+        # then
+        self.domino_service_mock.execute_lifecycle_command.assert_called_once_with(DominoCommand.STOP, "app1", None, True, None)
+
+    def test_should_execute_command_for_instance_stop_with_success(self):
+
+        # given
+        command_descriptor: CommandDescriptor = CommandDescriptor("stop app1 --instance standby")
+
+        # when
+        self.stop_application_command.execute_command(command_descriptor)
+
+        # then
+        self.domino_service_mock.execute_lifecycle_command.assert_called_once_with(DominoCommand.STOP, "app1", None, False, "standby")
 
     @mock.patch("builtins.print", side_effect=print)
     def test_should_execute_command_fail_on_validation(self, print_mock):

--- a/tests/core/service/test_DominoService.py
+++ b/tests/core/service/test_DominoService.py
@@ -22,13 +22,61 @@ class DominoServiceTest(unittest.TestCase):
     def test_should_execute_lifecycle_command_with_success(self, print_mock):
 
         # given
+        query = {"roll": "false"}
+
         self.domino_client_mock.send_command.return_value = DominoServiceTest._prepare_response(True)
 
         # when
         self.domino_service.execute_lifecycle_command(DominoCommand.DEPLOY_VERSION, "app1", version="1.0.0")
 
         # then
-        self._assert_client_call("/lifecycle/app1/deploy/1.0.0")
+        self._assert_client_call("/lifecycle/app1/deploy/1.0.0", expected_query_params=query)
+        self.assertEqual(print_mock.call_count, 6)
+        print_mock.assert_has_calls([
+            mock.call("[info ] Sending DEPLOY_VERSION command for application app1 via Domino"),
+            mock.call("[info ] Command DEPLOY_VERSION successfully executed on application app1"),
+            mock.call("[info ]  --- Response details ---"),
+            mock.call("[info ]              message: some details"),
+            mock.call("[info ]               status: ALL_OK"),
+            mock.call()
+        ])
+
+    @mock.patch("builtins.print", side_effect=print)
+    def test_should_execute_lifecycle_command_of_rolling_deploy_with_success(self, print_mock):
+
+        # given
+        query = {"roll": "true"}
+
+        self.domino_client_mock.send_command.return_value = DominoServiceTest._prepare_response(True)
+
+        # when
+        self.domino_service.execute_lifecycle_command(DominoCommand.DEPLOY_VERSION, "app1", version="1.0.0", roll=True)
+
+        # then
+        self._assert_client_call("/lifecycle/app1/deploy/1.0.0", expected_query_params=query)
+        self.assertEqual(print_mock.call_count, 6)
+        print_mock.assert_has_calls([
+            mock.call("[info ] Sending DEPLOY_VERSION command for application app1 via Domino"),
+            mock.call("[info ] Command DEPLOY_VERSION successfully executed on application app1"),
+            mock.call("[info ]  --- Response details ---"),
+            mock.call("[info ]              message: some details"),
+            mock.call("[info ]               status: ALL_OK"),
+            mock.call()
+        ])
+
+    @mock.patch("builtins.print", side_effect=print)
+    def test_should_execute_lifecycle_command_of_instance_deploy_with_success(self, print_mock):
+
+        # given
+        query = {"roll": "false", "instance": "primary"}
+
+        self.domino_client_mock.send_command.return_value = DominoServiceTest._prepare_response(True)
+
+        # when
+        self.domino_service.execute_lifecycle_command(DominoCommand.DEPLOY_VERSION, "app1", version="1.0.0", instance="primary")
+
+        # then
+        self._assert_client_call("/lifecycle/app1/deploy/1.0.0", expected_query_params=query)
         self.assertEqual(print_mock.call_count, 6)
         print_mock.assert_has_calls([
             mock.call("[info ] Sending DEPLOY_VERSION command for application app1 via Domino"),
@@ -43,13 +91,15 @@ class DominoServiceTest(unittest.TestCase):
     def test_should_execute_lifecycle_command_with_failure(self, print_mock):
 
         # given
+        query = {"roll": "false"}
+
         self.domino_client_mock.send_command.return_value = DominoServiceTest._prepare_response(False)
 
         # when
         self.domino_service.execute_lifecycle_command(DominoCommand.START, "app2")
 
         # then
-        self._assert_client_call("/lifecycle/app2/start")
+        self._assert_client_call("/lifecycle/app2/start", expected_query_params=query)
         print_mock.assert_has_calls([
             mock.call("[info ] Sending START command for application app2 via Domino"),
             mock.call("[error] Failed to execute command START on application app2 - Domino responded with 500")
@@ -59,13 +109,15 @@ class DominoServiceTest(unittest.TestCase):
     def test_should_execute_lifecycle_command_handle_exception(self, print_mock):
 
         # given
+        query = {"roll": "false"}
+
         self.domino_client_mock.send_command.side_effect = Exception("Mock client call failure")
 
         # when
         self.domino_service.execute_lifecycle_command(DominoCommand.STOP, "app3")
 
         # then
-        self._assert_client_call("/lifecycle/app3/stop", expected_method=HTTPMethod.DELETE)
+        self._assert_client_call("/lifecycle/app3/stop", expected_method=HTTPMethod.DELETE, expected_query_params=query)
         print_mock.assert_has_calls([
             mock.call("[info ] Sending STOP command for application app3 via Domino"),
             mock.call("[error] Failed to execute HTTP request [DELETE /lifecycle/app3/stop] - reason: Mock client call failure")

--- a/tests/core/service/wizard/test_DeploymentConfigWizard.py
+++ b/tests/core/service/wizard/test_DeploymentConfigWizard.py
@@ -13,6 +13,7 @@ _EXECUTABLE_TYPE_RAW_RESPONSES = [
     "devlocal",
     "localhost",
     "",
+    "2",
     "1",
     "1",
     "/home",
@@ -35,6 +36,7 @@ _EXECUTABLE_TYPE_FORMATTED_RESPONSE_DICT: dict = {
         "devlocal",
         "localhost"
     ],
+    "multi_instance_enable": "no",
     "source_type": "filesystem",
     "exec_type": "executable",
     "src_home": "/home",
@@ -57,6 +59,7 @@ _RUNTIME_TYPE_RAW_RESPONSES = [
     "app2",
     "localhost",
     "",
+    "2",
     "1",
     "2",
     "/home",
@@ -75,6 +78,7 @@ _RUNTIME_TYPE_FORMATTED_RESPONSE_DICT: dict = {
     "target_hosts": [
         "localhost"
     ],
+    "multi_instance_enable": "no",
     "exec_type": "runtime",
     "src_home": "/home",
     "src_bin_name": "app2-exec.jar",
@@ -92,6 +96,7 @@ _SERVICE_TYPE_RAW_RESPONSES = [
     "app3",
     "localhost",
     "",
+    "2",
     "1",
     "3",
     "/home",
@@ -108,6 +113,7 @@ _SERVICE_TYPE_FORMATTED_RESPONSE_DICT: dict = {
     "target_hosts": [
         "localhost"
     ],
+    "multi_instance_enable": "no",
     "exec_type": "service",
     "src_home": "/home",
     "src_bin_name": "app3-exec.jar",
@@ -121,6 +127,12 @@ _SERVICE_TYPE_FORMATTED_RESPONSE_DICT: dict = {
 _DOCKER_STANDARD_TYPE_RAW_RESPONSES = [
     "app4",
     "localhost",
+    "",
+    "1",
+    "2",
+    "1",
+    "1",
+    "+100",
     "",
     "2",
     "1",
@@ -157,6 +169,12 @@ _DOCKER_STANDARD_TYPE_FORMATTED_RESPONSE_DICT: dict = {
     "target_hosts": [
         "localhost"
     ],
+    "multi_instance_enable": "yes",
+    "instance_count": "2",
+    "spread_mode": "replicate",
+    "naming_strategy": "incremental-suffix",
+    "port_offset": "+100",
+    "host_network_base_port": None,
     "exec_type": "standard",
     "src_home": "http://localhost:5000/apps",
     "src_bin_name": "img_app4",
@@ -191,6 +209,103 @@ _DOCKER_STANDARD_TYPE_FORMATTED_RESPONSE_DICT: dict = {
     "result_rendering": "console"
 }
 
+_DOCKER_STANDARD_TYPE_RAW_RESPONSES_2 = [
+    "app4",
+    "localhost",
+    "host2",
+    "host3",
+    "",
+    "1",
+    "3",
+    "2",
+    "2",
+    "primary",
+    "secondary",
+    "standby",
+    "",
+    "-200",
+    "8200",
+    "2",
+    "1",
+    "http://localhost:5000/apps",
+    "img_app4",
+    "container_app4",
+    "9000:9000/tcp",
+    "8080:8080",
+    "",
+    "ENV_VAR1:value1",
+    "ENV_VAR2:value2",
+    "ENV_VAR3:value3",
+    "",
+    "/tmp1:/tmp1",
+    "/tmp2/something:/app/tmp:rw",
+    "/tmp3/tmp:/app/something:ro",
+    "",
+    "host",
+    "4",
+    "--param1",
+    "--param2",
+    "",
+    "2",
+    "1",
+    "http://localhost:9000/actuator/info",
+    "name:$.app.name",
+    "version:$.build.version",
+    "",
+    "1"
+]
+_DOCKER_STANDARD_TYPE_FORMATTED_RESPONSE_DICT_2: dict = {
+    "deployment_name": "app4",
+    "source_type": "docker",
+    "target_hosts": [
+        "localhost",
+        "host2",
+        "host3"
+    ],
+    "multi_instance_enable": "yes",
+    "instance_count": "3",
+    "spread_mode": "one-per-host",
+    "naming_strategy": "custom-predefined",
+    "defined_names": [
+        "primary",
+        "secondary",
+        "standby"
+    ],
+    "port_offset": "-200",
+    "host_network_base_port": "8200",
+    "exec_type": "standard",
+    "src_home": "http://localhost:5000/apps",
+    "src_bin_name": "img_app4",
+    "exec_cmd_name": "container_app4",
+    "exec_args_docker_ports": {
+        "9000": "9000/tcp",
+        "8080": "8080"
+    },
+    "exec_args_docker_env": {
+        "ENV_VAR1": "value1",
+        "ENV_VAR2": "value2",
+        "ENV_VAR3": "value3"
+    },
+    "exec_args_docker_volumes": {
+        "/tmp1": "/tmp1",
+        "/tmp2/something": "/app/tmp:rw",
+        "/tmp3/tmp": "/app/something:ro"
+    },
+    "exec_args_docker_network": "host",
+    "exec_args_docker_restart": "unless-stopped",
+    "exec_args_docker_cmd": [
+        "--param1",
+        "--param2"
+    ],
+    "hc_enable": "no",
+    "info_enable": "yes",
+    "info_endpoint": "http://localhost:9000/actuator/info",
+    "info_field_mapping": {
+        "name": "$.app.name",
+        "version": "$.build.version"
+    },
+    "result_rendering": "console"
+}
 
 class DeploymentConfigWizardTest(unittest.TestCase):
 
@@ -248,6 +363,16 @@ class DeploymentConfigWizardTest(unittest.TestCase):
 
         # then
         self.wizard_result_transformer_mock.transform.assert_called_once_with(_DOCKER_STANDARD_TYPE_FORMATTED_RESPONSE_DICT)
+        self.wizard_result_console_renderer_mock.render.assert_called_once_with(_TRANSFORMED_VALUE)
+
+    @mock.patch("builtins.input", side_effect=_DOCKER_STANDARD_TYPE_RAW_RESPONSES_2)
+    def test_should_run_wizard_for_docker_standard_type_and_console_rendering_2(self, input_mock):
+
+        # when
+        self.deployment_config_wizard.run()
+
+        # then
+        self.wizard_result_transformer_mock.transform.assert_called_once_with(_DOCKER_STANDARD_TYPE_FORMATTED_RESPONSE_DICT_2)
         self.wizard_result_console_renderer_mock.render.assert_called_once_with(_TRANSFORMED_VALUE)
 
 

--- a/tests/core/service/wizard/transformer/test_DeploymentConfigWizardResultTransformer.py
+++ b/tests/core/service/wizard/transformer/test_DeploymentConfigWizardResultTransformer.py
@@ -8,6 +8,7 @@ _DEPLOYMENT_CONFIG_EXECUTABLE_RAW: dict = {
         "devlocal",
         "localhost"
     ],
+    "multi_instance_enable": "no",
     "source_type": "filesystem",
     "exec_type": "executable",
     "src_home": "/home",
@@ -37,7 +38,10 @@ _DEPLOYMENT_CONFIG_EXECUTABLE_TRANSFORMED: dict = {
                     "hosts": [
                         "devlocal",
                         "localhost"
-                    ]
+                    ],
+                    "multi-instance": {
+                        "enabled": False
+                    }
                 },
                 "execution": {
                     "via": "EXECUTABLE",
@@ -67,6 +71,7 @@ _DEPLOYMENT_CONFIG_RUNTIME_RAW: dict = {
     "target_hosts": [
         "localhost"
     ],
+    "multi_instance_enable": "no",
     "source_type": "filesystem",
     "exec_type": "runtime",
     "src_home": "/home",
@@ -96,7 +101,10 @@ _DEPLOYMENT_CONFIG_RUNTIME_TRANSFORMED: dict = {
                 "target": {
                     "hosts": [
                         "localhost"
-                    ]
+                    ],
+                    "multi-instance": {
+                        "enabled": False
+                    }
                 },
                 "execution": {
                     "via": "RUNTIME",
@@ -127,6 +135,7 @@ _DEPLOYMENT_CONFIG_SERVICE_RAW: dict = {
     "target_hosts": [
         "localhost"
     ],
+    "multi_instance_enable": "no",
     "source_type": "filesystem",
     "exec_type": "service",
     "src_home": "/home",
@@ -148,7 +157,10 @@ _DEPLOYMENT_CONFIG_SERVICE_TRANSFORMED: dict = {
                 "target": {
                     "hosts": [
                         "localhost"
-                    ]
+                    ],
+                    "multi-instance": {
+                        "enabled": False
+                    }
                 },
                 "execution": {
                     "via": "SERVICE",
@@ -171,6 +183,11 @@ _DEPLOYMENT_CONFIG_DOCKER_STANDARD_RAW: dict = {
     "target_hosts": [
         "localhost"
     ],
+    "multi_instance_enable": "yes",
+    "instance_count": "2",
+    "spread_mode": "replicate",
+    "naming_strategy": "incremental-suffix",
+    "port_offset": "+100",
     "source_type": "docker",
     "exec_type": "standard",
     "src_home": "http://localhost:5000/apps",
@@ -211,7 +228,16 @@ _DEPLOYMENT_CONFIG_DOCKER_STANDARD_TRANSFORMED: dict = {
                 "target": {
                     "hosts": [
                         "localhost"
-                    ]
+                    ],
+                    "multi-instance": {
+                        "enabled": True,
+                        "instance-count": 2,
+                        "spread-mode": "replicate",
+                        "naming-strategy": "incremental-suffix",
+                        "defined-names": None,
+                        "port-offset": 100,
+                        "host-network-base-port": None
+                    }
                 },
                 "execution": {
                     "via": "STANDARD",
@@ -250,6 +276,117 @@ _DEPLOYMENT_CONFIG_DOCKER_STANDARD_TRANSFORMED: dict = {
     }
 }
 
+_DEPLOYMENT_CONFIG_DOCKER_STANDARD_RAW_2: dict = {
+    "deployment_name": "app4",
+    "target_hosts": [
+        "localhost",
+        "host2",
+        "host3"
+    ],
+    "multi_instance_enable": "yes",
+    "instance_count": "3",
+    "spread_mode": "one-per-host",
+    "naming_strategy": "custom-predefined",
+    "defined_names": [
+        "primary",
+        "secondary",
+        "standby"
+    ],
+    "port_offset": "-200",
+    "host_network_base_port": "8200",
+    "source_type": "docker",
+    "exec_type": "standard",
+    "src_home": "http://localhost:5000/apps",
+    "src_bin_name": "img_app4",
+    "exec_cmd_name": "container_app4",
+    "exec_args_docker_ports": {
+        "9000": "9000/tcp",
+        "8080": "8080"
+    },
+    "exec_args_docker_env": {
+        "ENV_VAR1": "value1",
+        "ENV_VAR2": "value2",
+        "ENV_VAR3": "value3"
+    },
+    "exec_args_docker_volumes": {
+        "/tmp1": "/tmp1",
+        "/tmp2/something": "/app/tmp:rw",
+        "/tmp3/tmp": "/app/something:ro"
+    },
+    "exec_args_docker_network": "host",
+    "exec_args_docker_restart": "unless-stopped",
+    "exec_args_docker_cmd": [
+        "--param1",
+        "--param2"
+    ],
+    "hc_enable": "no",
+    "info_enable": "no"
+}
+_DEPLOYMENT_CONFIG_DOCKER_STANDARD_TRANSFORMED_2: dict = {
+    "domino": {
+        "deployments": {
+            "app4": {
+                "source": {
+                    "type": "DOCKER",
+                    "home": "http://localhost:5000/apps",
+                    "resource": "img_app4"
+                },
+                "target": {
+                    "hosts": [
+                        "localhost",
+                        "host2",
+                        "host3"
+                    ],
+                    "multi-instance": {
+                        "enabled": True,
+                        "instance-count": 3,
+                        "spread-mode": "one-per-host",
+                        "naming-strategy": "custom-predefined",
+                        "defined-names": [
+                            "primary",
+                            "secondary",
+                            "standby"
+                        ],
+                        "port-offset": -200,
+                        "host-network-base-port": 8200
+                    }
+                },
+                "execution": {
+                    "via": "STANDARD",
+                    "command-name": "container_app4",
+                    "args": {
+                        "ports": {
+                            "9000": "9000/tcp",
+                            "8080": "8080"
+                        },
+                        "environment": {
+                            "ENV_VAR1": "value1",
+                            "ENV_VAR2": "value2",
+                            "ENV_VAR3": "value3"
+                        },
+                        "volumes": {
+                            "/tmp1": "/tmp1",
+                            "/tmp2/something": "/app/tmp:rw",
+                            "/tmp3/tmp": "/app/something:ro"
+                        },
+                        "network-mode": "host",
+                        "restart-policy": "unless-stopped",
+                        "command-args": [
+                            "--param1",
+                            "--param2"
+                        ]
+                    }
+                },
+                "health-check": {
+                    "enabled": False
+                },
+                "info": {
+                    "enabled": False
+                }
+            }
+        }
+    }
+}
 
 class DeploymentConfigWizardResultTransformerTest(unittest.TestCase):
 
@@ -273,7 +410,8 @@ class DeploymentConfigWizardResultTransformerTest(unittest.TestCase):
             (_DEPLOYMENT_CONFIG_EXECUTABLE_RAW, _DEPLOYMENT_CONFIG_EXECUTABLE_TRANSFORMED),
             (_DEPLOYMENT_CONFIG_RUNTIME_RAW, _DEPLOYMENT_CONFIG_RUNTIME_TRANSFORMED),
             (_DEPLOYMENT_CONFIG_SERVICE_RAW, _DEPLOYMENT_CONFIG_SERVICE_TRANSFORMED),
-            (_DEPLOYMENT_CONFIG_DOCKER_STANDARD_RAW, _DEPLOYMENT_CONFIG_DOCKER_STANDARD_TRANSFORMED)
+            (_DEPLOYMENT_CONFIG_DOCKER_STANDARD_RAW, _DEPLOYMENT_CONFIG_DOCKER_STANDARD_TRANSFORMED),
+            (_DEPLOYMENT_CONFIG_DOCKER_STANDARD_RAW_2, _DEPLOYMENT_CONFIG_DOCKER_STANDARD_TRANSFORMED_2)
         ]
 
 


### PR DESCRIPTION
 - Added support for multi-instance deployments (for the Domino lifecycle API and the deployment configuration wizard)
 - Added new and aligned existing unit tests
 - Updated documentation
 - Bumped application version to 2.6.0